### PR TITLE
feat(test): add junit reports and progress tracking to e2e tests

### DIFF
--- a/docs/testing/replication-e2e-suite.md
+++ b/docs/testing/replication-e2e-suite.md
@@ -85,8 +85,8 @@ make test-replication-e2e GINKGO_FOCUS="L1-E-001"
 |--------------------------------|-----------------------------------------------------------------------------|----------------|
 | `GINKGO_FOCUS`                 | Ginkgo focus expression to run only matching specs                         | (run all)      |
 | `INSTALL_CRDS`                 | Set to `true` to install CRDs from `deploy/controller/crds.yaml` if missing | `false`        |
-| `STORAGE_CLASS`                | StorageClass name used for test PVCs                                       | auto-detect    |
-| `CSI_PROVISIONER`              | Provisioner name for VolumeReplicationClass                                | auto-detect    |
+| `STORAGE_CLASS`                | StorageClass name used for test PVCs. Not auto-detected from the cluster; defaults match typical Rook-Ceph block storage. | `rook-ceph-block` |
+| `CSI_PROVISIONER`              | VolumeReplicationClass provisioner; must match CSIAddonsNode `spec.driver.name`. Not auto-detected; default matches Rook-Ceph RBD. | `rook-ceph.rbd.csi.ceph.com` |
 | `REPLICATION_SECRET_NAME`      | Name of existing secret for replication (use with `REPLICATION_SECRET_NAMESPACE`) | (create per-namespace secret) |
 | `REPLICATION_SECRET_NAMESPACE` | Namespace of existing replication secret                                   | (create per-namespace secret) |
 | `REPLICATION_POLL_TIMEOUT`     | Timeout in seconds for waiting on Replicating=True (and error conditions)  | `300` |

--- a/hack/run-replication-e2e.sh
+++ b/hack/run-replication-e2e.sh
@@ -12,8 +12,8 @@
 #   GINKGO_FOCUS        - Ginkgo focus expression to run only matching tests (default: run all).
 #                          Examples: "L1-E-001", "EnableVolumeReplication", "GetVolumeReplicationInfo"
 #   INSTALL_CRDS         - "true" to install CRDs before tests if missing (default: "false")
-#   STORAGE_CLASS        - StorageClass name for PVCs (default: auto-detect or "rook-ceph-block")
-#   CSI_PROVISIONER      - Must match CSIAddonsNode .spec.driver.name (default: "rook-ceph.rbd.csi.ceph.com").
+#   STORAGE_CLASS        - StorageClass name for PVCs (default: "rook-ceph-block"; not auto-detected).
+#   CSI_PROVISIONER      - Must match CSIAddonsNode .spec.driver.name (default: "rook-ceph.rbd.csi.ceph.com"; not auto-detected).
 #                          If state stays Unknown, run ./hack/diagnose-replication-vr.sh and set this.
 #   REPLICATION_SECRET_NAME, REPLICATION_SECRET_NAMESPACE - If both set, use this existing secret
 #                          for VolumeReplicationClass (e.g. rook-csi-rbd-provisioner in rook-ceph).
@@ -92,8 +92,8 @@ echo "  REPLICATION_TEST_TIMEOUT=${REPLICATION_TEST_TIMEOUT:-30m} (go test -time
 echo "  REPLICATION_POLL_TIMEOUT=${REPLICATION_POLL_TIMEOUT:-<default 300>}"
 echo "  REPLICATION_SECRET_NAME=${REPLICATION_SECRET_NAME:-<unset, create per-ns secret>}"
 echo "  REPLICATION_SECRET_NAMESPACE=${REPLICATION_SECRET_NAMESPACE:-<unset>}"
-echo "  STORAGE_CLASS=${STORAGE_CLASS:-<auto>}"
-echo "  CSI_PROVISIONER=${CSI_PROVISIONER:-<auto>}"
+echo "  STORAGE_CLASS=${STORAGE_CLASS:-rook-ceph-block}"
+echo "  CSI_PROVISIONER=${CSI_PROVISIONER:-rook-ceph.rbd.csi.ceph.com}"
 echo "  DR1_CONTEXT=${DR1_CONTEXT:-<unset>}"
 echo "  DR2_CONTEXT=${DR2_CONTEXT:-<unset>}"
 echo "  GINKGO_FOCUS=${GINKGO_FOCUS:-<all>}"

--- a/test/e2e/helpers/progress_reporter.go
+++ b/test/e2e/helpers/progress_reporter.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+const (
+	// DefaultReportDirName is the default directory name for test reports
+	DefaultReportDirName = "Reports"
+	// DefaultProgressReportFileName is the default filename for progress reports
+	DefaultProgressReportFileName = "progress_report.txt"
+)
+
+// ProgressReporter tracks and reports test progress
+type ProgressReporter struct {
+	startTime  time.Time
+	testCount  int
+	passCount  int
+	failCount  int
+	skipCount  int
+	testsTotal int
+	reportFile string
+}
+
+// NewProgressReporter creates a new progress reporter
+func NewProgressReporter(reportDir string) *ProgressReporter {
+	pr := &ProgressReporter{
+		startTime: time.Now(),
+	}
+
+	// Ensure reportDir is an absolute path
+	if reportDir == "" {
+		reportDir = DefaultReportDirName
+	}
+
+	if !filepath.IsAbs(reportDir) {
+		// If relative, make it absolute from current working directory
+		wd, err := os.Getwd()
+		if err == nil {
+			reportDir = filepath.Join(wd, reportDir)
+		}
+	}
+
+	// Create the directory if it doesn't exist
+	if err := os.MkdirAll(reportDir, 0755); err != nil {
+		fmt.Printf("[PROGRESS] Error creating report directory %s: %v\n", reportDir, err)
+	}
+
+	// Set up report file path
+	pr.reportFile = filepath.Join(reportDir, DefaultProgressReportFileName)
+
+	return pr
+}
+
+// SetStartMsg logs the start of the test suite
+func (pr *ProgressReporter) SetStartMsg(suiteName string) {
+	msg := fmt.Sprintf("=== %s Started at %s ===\n", suiteName, pr.startTime.Format(time.RFC3339))
+	pr.writeToReport(msg)
+}
+
+// SetEndMsg logs the end of the test suite
+func (pr *ProgressReporter) SetEndMsg(suiteName string) {
+	elapsed := time.Since(pr.startTime)
+	msg := fmt.Sprintf("\n=== %s Completed ===\n"+
+		"Duration: %v\n"+
+		"Total Tests: %d\n"+
+		"Passed: %d\n"+
+		"Failed: %d\n"+
+		"Skipped: %d\n"+
+		"End Time: %s\n",
+		suiteName, elapsed, pr.testCount, pr.passCount, pr.failCount, pr.skipCount,
+		time.Now().Format(time.RFC3339))
+	pr.writeToReport(msg)
+}
+
+// AddProgress records test progress
+func (pr *ProgressReporter) AddProgress(testName string, status string) {
+	msg := fmt.Sprintf("[%s] %s - %s\n", time.Now().Format("15:04:05"), testName, status)
+	pr.writeToReport(msg)
+
+	pr.testCount++
+	switch status {
+	case "PASS":
+		pr.passCount++
+	case "FAIL":
+		pr.failCount++
+	case "SKIP":
+		pr.skipCount++
+	}
+}
+
+// SetTestsTotal sets the total number of tests that will run
+func (pr *ProgressReporter) SetTestsTotal(total int) {
+	pr.testsTotal = total
+	msg := fmt.Sprintf("Total tests to run: %d\n", total)
+	pr.writeToReport(msg)
+}
+
+// ProcessSpecReport processes individual spec reports for real-time progress tracking
+func (pr *ProgressReporter) ProcessSpecReport(report types.SpecReport) {
+	// Skip lifecycle hooks and internal specs
+	fullText := strings.TrimSpace(report.FullText())
+	if fullText == "" ||
+		strings.Contains(fullText, "[BeforeSuite]") ||
+		strings.Contains(fullText, "[AfterSuite]") ||
+		strings.Contains(fullText, "[BeforeEach]") ||
+		strings.Contains(fullText, "[AfterEach]") ||
+		strings.HasPrefix(fullText, "TOP-LEVEL") {
+		return
+	}
+
+	// Determine status
+	var status string
+	switch report.State {
+	case types.SpecStatePassed:
+		status = "PASS"
+		pr.passCount++
+	case types.SpecStateSkipped, types.SpecStatePending:
+		status = "SKIP"
+		pr.skipCount++
+	default:
+		if report.Failed() {
+			status = "FAIL"
+			pr.failCount++
+		} else {
+			return
+		}
+	}
+
+	pr.testCount++
+
+	// Log progress
+	duration := report.RunTime.Round(time.Millisecond)
+	msg := fmt.Sprintf("[%s] %s - %s (%s)\n", time.Now().Format("15:04:05"), fullText, status, duration)
+	pr.writeToReport(msg)
+}
+
+// writeToReport writes progress to report file if configured
+func (pr *ProgressReporter) writeToReport(msg string) {
+	if pr.reportFile == "" {
+		return
+	}
+
+	// Append to report file (file should already exist from NewProgressReporter)
+	f, err := os.OpenFile(pr.reportFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("[PROGRESS] Warning: could not open report file %s: %v\n", pr.reportFile, err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(msg); err != nil {
+		fmt.Printf("[PROGRESS] Warning: could not write to report file %s: %v\n", pr.reportFile, err)
+	}
+}

--- a/test/e2e/replication/suite_test.go
+++ b/test/e2e/replication/suite_test.go
@@ -129,8 +129,9 @@ func TestReplicationE2E(t *testing.T) {
 	// Configure Ginkgo with JUnit reporter
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 
-	// Set up JUnit report file
-	junitReportPath := filepath.Join(reportDir, "junit_report.xml")
+	// Set up JUnit report file with timestamp to avoid overwriting previous runs
+	timestamp := time.Now().Format("2006-01-02T15-04-05")
+	junitReportPath := filepath.Join(reportDir, fmt.Sprintf("junit_report_%s.xml", timestamp))
 	reporterConfig.JUnitReport = junitReportPath
 
 	// Run specs

--- a/test/e2e/replication/suite_test.go
+++ b/test/e2e/replication/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -41,6 +42,7 @@ import (
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
 
 // Cluster names for full-DR mode (when DR1_CONTEXT and DR2_CONTEXT are both set).
@@ -48,6 +50,31 @@ const (
 	ClusterDR1 = "dr1"
 	ClusterDR2 = "dr2"
 )
+
+// findProjectRoot locates the project root by searching for go.mod file
+// starting from the current working directory and moving up the directory tree.
+func findProjectRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for dir := cwd; ; {
+		gomod := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(gomod); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached the root of the filesystem
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("go.mod not found")
+}
 
 var (
 	cfg                            *rest.Config
@@ -61,9 +88,24 @@ var (
 	networkFenceSupportProvisioner string // provisioner used for cached check
 	sigChan                        chan os.Signal
 	cleanupNamespaces              []string // track test namespaces for forced-termination cleanup
+	progressReporter               *helpers.ProgressReporter
+	reportDir                      string
 )
 
 func init() {
+	// Initialize reportDir to root Reports directory
+	// Try to use REPORTS_DIR environment variable, otherwise find project root
+	reportDir = os.Getenv("REPORTS_DIR")
+	if reportDir == "" {
+		// Find project root by locating go.mod
+		if projectRoot, err := findProjectRoot(); err == nil {
+			reportDir = filepath.Join(projectRoot, "Reports")
+		} else {
+			// Fallback to relative path
+			reportDir = helpers.DefaultReportDirName
+		}
+	}
+
 	// Setup signal handler for graceful cleanup on forced termination (SIGTERM, SIGINT)
 	// This catches termination signals before process is killed
 	sigChan = make(chan os.Signal, 1)
@@ -78,8 +120,24 @@ func init() {
 }
 
 func TestReplicationE2E(t *testing.T) {
+	// Create progress reporter
+	progressReporter = helpers.NewProgressReporter(reportDir)
+	progressReporter.SetStartMsg("Replication E2E Test Suite")
+
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Replication E2E Suite")
+
+	// Configure Ginkgo with JUnit reporter
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	// Set up JUnit report file
+	junitReportPath := filepath.Join(reportDir, "junit_report.xml")
+	reporterConfig.JUnitReport = junitReportPath
+
+	// Run specs
+	RunSpecs(t, "Replication E2E Suite", suiteConfig, reporterConfig)
+
+	// Final progress report
+	progressReporter.SetEndMsg("Replication E2E Test Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -139,7 +197,17 @@ var _ = BeforeSuite(func() {
 	Logf("[SETUP]", "NetworkFence support = %v (provisioner=%q)", isSupported, testEnv.Provisioner)
 })
 
-// ReportAfterEach logs each spec's completion for progress visibility in logs.
+// ReportBeforeSuite sets the total test count at the beginning of the suite
+var _ = ReportBeforeSuite(func(report Report) {
+	progressReporter.SetTestsTotal(report.PreRunStats.SpecsThatWillRun)
+})
+
+// ReportAfterEach tracks individual spec results for real-time progress
+var _ = ReportAfterEach(func(report SpecReport) {
+	progressReporter.ProcessSpecReport(report)
+})
+
+// ReportAfterEachLegacy logs each spec's completion for progress visibility in logs.
 var _ = ReportAfterEach(func(report types.SpecReport) {
 	stateStr := report.State.String()
 	dur := report.RunTime.Round(time.Millisecond)


### PR DESCRIPTION
Add junit utilities and progress reporting to replication e2e test suite

## Changes
- Add junit reports and progress tracking to replication e2e tests
- Add timestamp to junit report filename to prevent overwriting previous runs
- Document env variable default values

## Commits
- 7d756439 feat: add junit reports and progress tracking to replication e2e tests
- 10337527 fix: add timestamp to junit report filename to prevent overwriting previous runs
- bdad0790 doc: env variable define default values

## Part of PR #17 Refactoring
This is part of a larger refactoring of PR #17 into smaller, focused pull requests.
Depends on: None
Unblocks: PR-helpers, PR-fault-injection, PR-test-refactor, PR-hooks