### PR TITLE
refactor(test): update tests to use fault injection framework

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -29,10 +29,10 @@ jobs:
     name: ceph
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
       - name: Install cri-dockerd

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,6 +7,8 @@ ignore:
   - bundle/
   # vendor/ are maintained elsewhere
   - vendor/
+  # Template files contain Go templating syntax that yamllint cannot parse
+  - test/e2e/helpers/templates/
 
 rules:
   document-start:

--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ Refer to the [installation guide](docs/deploy-controller.md) for more details.
 
 See [Testing Architecture](docs/testing-architecture.md) for a full overview. Summary of what exists:
 
-| Category | What exists | Notes |
-|----------|-------------|--------|
-| **Unit tests** | Client replication API (enable/disable/promote/demote/resync), controller helpers, PVC annotations | Use fake gRPC clients; no real cluster or CSI driver. |
-| **Controller integration** | Replication Storage Suite, CSI-Addons Suite | Use [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) (or real cluster with `USE_EXISTING_CLUSTER=true`). Controllers are exercised with **fake** clients—no real gRPC to sidecars. |
-| **Replication E2E** | Layer-1 VR scenarios in `test/e2e/replication` | Create VolumeReplication/VolumeReplicationClass on a live cluster; require controller and CSI driver with replication support. See [Replication E2E Suite](docs/testing/replication-e2e-suite.md). |
+| Category                   | What exists                                                                                        | Notes                                                                                                                                                                                                            |
+| -------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Unit tests**             | Client replication API (enable/disable/promote/demote/resync), controller helpers, PVC annotations | Use fake gRPC clients; no real cluster or CSI driver.                                                                                                                                                            |
+| **Controller integration** | Replication Storage Suite, CSI-Addons Suite                                                        | Use [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) (or real cluster with `USE_EXISTING_CLUSTER=true`). Controllers are exercised with **fake** clients—no real gRPC to sidecars.       |
+| **Replication end-to-end** | Layer-1 VR scenarios in `test/e2e/replication`                                                     | Create VolumeReplication/VolumeReplicationClass on a live cluster; require controller and CSI driver with replication support. See [Replication E2E suite](docs/testing/replication-e2e-suite.md). |
 
 **Run tests:**
 
 - All tests (envtest, no cluster): `make test`
 - Replication controller + client against existing cluster (KUBECONFIG, CRDs): `make test-replication-cluster` or `./hack/run-ceph-replication-addon.sh`.
-- Replication E2E suite against existing cluster (controller + CSI driver required): `make test-replication-e2e` or `./hack/run-replication-e2e.sh`. Use `GINKGO_FOCUS` to run specific tests (e.g. `GINKGO_FOCUS="L1-E-001" ./hack/run-replication-e2e.sh`). See [Replication E2E Suite](docs/testing/replication-e2e-suite.md).
+- Replication end-to-end suite against existing cluster (controller + CSI driver required): `make test-replication-e2e` or `./hack/run-replication-e2e.sh`. Use `GINKGO_FOCUS` to run specific tests (e.g. `GINKGO_FOCUS="L1-E-001" ./hack/run-replication-e2e.sh`). See [Replication E2E suite](docs/testing/replication-e2e-suite.md).
 
 ## Contributing
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,11 +1,12 @@
+---
 # Adds namespace to all resources.
 namespace: csi-addons-system
 
 # Labels to add to all resources and selectors.
-#labels:
-#- includeSelectors: true
-#  pairs:
-#    someName: someValue
+# labels:
+# - includeSelectors: true
+#   pairs:
+#     someName: someValue
 
 resources:
   - ../crd
@@ -13,41 +14,41 @@ resources:
   - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+# - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+# - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+# - ../prometheus
 # [METRICS] To enable the controller manager metrics service, uncomment the following line.
-#- metrics_service.yaml
+# - metrics_service.yaml
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
-#patches:
+# patches:
 # [METRICS] The following patch will enable the metrics endpoint. Ensure that you also protect this endpoint.
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
-#- path: manager_metrics_patch.yaml
-#  target:
-#    kind: Deployment
+# - path: manager_metrics_patch.yaml
+#   target:
+#     kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
+# - path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- path: webhookcainjection_patch.yaml
+# - path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
-#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
-#      kind: Certificate
-#      group: cert-manager.io
-#      version: v1
-#      name: serving-cert # this name should match the one in certificate.yaml
-#      fieldPath: .metadata.namespace # namespace of the certificate CR
+# replacements:
+#   - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+#       kind: Certificate
+#       group: cert-manager.io
+#       version: v1
+#       name: serving-cert # this name should match the one in certificate.yaml
+#       fieldPath: .metadata.namespace # namespace of the certificate CR
 #    targets:
 #      - select:
 #          kind: ValidatingWebhookConfiguration

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,12 +10,12 @@ namePrefix: csi-addons-
 
 resources:
 - manager.yaml
-#- metrics_service.yaml
+# - metrics_service.yaml
 
-#patches:
-#- path: manager_metrics_patch.yaml
-#  target:
-#    kind: Deployment
+# patches:
+# - path: manager_metrics_patch.yaml
+#   target:
+#     kind: Deployment
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/docs/development/git-hooks.md
+++ b/docs/development/git-hooks.md
@@ -1,0 +1,335 @@
+# Git Pre-commit Hooks
+
+This repository uses Git pre-commit hooks to catch linting issues locally before they're pushed to the CI pipeline.
+
+## Setup
+
+### Automatic Setup (Recommended)
+
+After cloning the repository, run:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
+This will install all pre-commit hooks to `.Git/hooks/` and make them executable.
+
+### Manual Setup
+
+If you prefer to set up manually:
+
+```bash
+cp scripts/hooks/* .Git/hooks/
+chmod +x .Git/hooks/*
+```
+
+## Available Hooks
+
+### pre-commit
+
+Runs **shellcheck**, **yamllint**, **bash -n**, **shfmt**, **markdownlint**, and **Prettier** (`prettier@3.5.3` for Markdown, matching the GitHub Actions super-linter **MARKDOWN_PRETTIER** check) on staged files before allowing a commit.
+
+**What it does:**
+
+- Checks all modified/staged shell scripts (`.sh`) with shellcheck
+- Checks all modified/staged shell scripts syntax with bash -n (BASH_EXEC)
+- Checks all modified/staged shell scripts formatting with shfmt (SHELL_SHFMT)
+- Checks all modified/staged YAML files (`.yaml`, `.yml`) with yamllint
+- Checks all modified/staged Markdown files (`.md`) with markdownlint
+- Checks all modified/staged Markdown files with Prettier (`npx prettier@3.5.3 --check`, same as CI **MARKDOWN_PRETTIER**)
+- Prevents commits if any linting errors are found
+- Shows detailed error messages to help you fix issues
+- Only checks for linting tools if files of that type are present
+
+**CI parity:** The workflow [lint-extras.yaml](../../.github/workflows/lint-extras.yaml) also runs **NATURAL_LANGUAGE** (textlint) on Markdown; that check is **not** in the hook. See [CI pipeline (super-linter) versus pre-commit](#ci-pipeline-super-linter-versus-pre-commit).
+
+**Example output:**
+
+```plaintext
+Running pre-commit linting checks...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Shellcheck (Shell scripts)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Checking hack/run-replication-e2e.sh... Pass
+Shellcheck: 1 passed, 0 failed
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Yamllint (YAML files)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Checking config/manager/kustomization.yaml... Pass
+Yamllint: 1 passed, 0 failed
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Linting Summary:
+  Passed: 2
+  Failed: 0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+All files passed linting!
+```
+
+**Example when there are errors:**
+
+```plaintext
+Running pre-commit linting checks...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Shellcheck (Shell scripts)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Checking hack/example.sh... FAILED
+
+In hack/example.sh line 22:
+  local var=$(echo "test")
+         ^-- SC2155: Declare and assign separately...
+
+Shellcheck: 0 passed, 1 failed
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Linting Summary:
+  Passed: 0
+  Failed: 1
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+BLOCKED: Commit blocked: Fix linting errors above and try again
+
+Files with errors:
+  - hack/example.sh
+```
+
+## Bypassing Hooks (Skip Hook for Single Commit)
+
+If you need to bypass the pre-commit hook for **a single commit** (not recommended), you can use:
+
+```bash
+Git commit --no-verify
+```
+
+**Important**: The CI pipeline will still run the same checks and **fail if linting issues exist**. This should only be used as a temporary measure while you work on fixes.
+
+**Example:**
+
+```bash
+Git add .
+Git commit --no-verify -m "WIP: fixing linting issues"
+# ... now run shellcheck and fix the issues
+# Then commit again without --no-verify to verify it passes
+```
+
+**WARNING**: Using `--no-verify` repeatedly means your code won't be validated locally. Use only when necessary.
+
+## Requirements
+
+### Required Tools
+
+- `Git` - Version control
+- `shellcheck` - Shell script linting
+- `yamllint` - YAML file linting
+
+### Optional Tools (Recommended for Full Validation)
+
+- `shfmt` - Shell script formatting checker
+- `bash` - Shell syntax validator (usually pre-installed)
+- `markdownlint` - Markdown file linting (**install for MARKDOWN CI parity**)
+- Node.js (`npx`) - Required for Prettier checks in the hook (**install for MARKDOWN_PRETTIER CI parity**)
+
+### Installing shellcheck
+
+- **macOS**: `brew install shellcheck`
+- **Ubuntu/Debian**: `apt-get install shellcheck`
+- **Fedora/RHEL**: `dnf install ShellCheck`
+- **Other**: See [shellcheck on GitHub](https://github.com/koalaman/shellcheck)
+
+### Installing yamllint
+
+- **macOS**: `brew install yamllint`
+- **Ubuntu/Debian**: `apt-get install yamllint`
+- **Fedora/RHEL**: `dnf install yamllint`
+- **Python/pip**: `pip install yamllint`
+- **Other**: See [yamllint on GitHub](https://github.com/adrienverge/yamllint)
+
+### Installing shfmt (Recommended)
+
+- **macOS**: `brew install shfmt`
+- **Ubuntu/Debian**: `apt-get install shfmt`
+- **Fedora/RHEL**: `dnf install shfmt`
+- **Go**: `go install mvdan.cc/sh/v3/cmd/shfmt@latest`
+
+### Installing markdownlint (Recommended)
+
+- **Node.js**: `npm install -g markdownlint`
+- **Ubuntu/Debian**: May be available as `node-markdownlint`
+- **Python**: `pip install markdownlint` (or `mdl`)
+
+**Note:** If a tool for a given file type is missing, the hook warns and **skips** that check (for example no `markdownlint` means **MARKDOWN** is not validated locally). Install all recommended tools so local runs match `.github/workflows/lint-extras.yaml` for shell, YAML, and Markdown.
+
+## Testing Hooks Locally
+
+To test if your shell scripts pass linting before committing:
+
+```bash
+# Check a specific file
+shellcheck hack/run-replication-e2e.sh
+
+# Check all shell files
+find . -name "*.sh" -type f | xargs shellcheck
+```
+
+## Updating Hooks
+
+When hooks are updated in the repository, reinstall them:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
+## Disabling Hooks Temporarily (Multiple Commits)
+
+If you need to **disable hooks for multiple commits** without verification:
+
+### Option 1: Make Hook Non-Executable (Recommended for temporary work)
+
+```bash
+# Disable the hook
+chmod -x .Git/hooks/pre-commit
+
+# Now perform your commits without hook checks
+Git add .
+Git commit -m "WIP: work in progress"
+Git commit -m "Continue working"
+
+# Re-enable the hook when done
+./scripts/setup-hooks.sh
+```
+
+**Verify the hook status:**
+
+```bash
+# Check if hook is executable (enabled)
+ls -la .Git/hooks/pre-commit
+# Expected: -rwxr-xr-x (executable)
+
+# Disabled hook shows:
+# Expected: -rw-r--r-- (not executable, no 'x')
+```
+
+### Option 2: Uninstall Hooks Temporarily
+
+```bash
+# Remove the installed hook
+rm .Git/hooks/pre-commit
+
+# Perform commits without checking
+Git add .
+Git commit -m "WIP: work in progress"
+
+# Reinstall the hook
+./scripts/setup-hooks.sh
+```
+
+### Option 3: Use --no-verify for Each Commit
+
+```bash
+# Bypass hook for individual commits
+Git commit --no-verify -m "Commit message"
+```
+
+**When to use each option:**
+
+| Scenario                      | Method        | Command                          |
+| ----------------------------- | ------------- | -------------------------------- |
+| Single commit to bypass       | `--no-verify` | `Git commit --no-verify`         |
+| Multiple commits (dev branch) | Disable hook  | `chmod -x .Git/hooks/pre-commit` |
+| Completely remove hook        | Uninstall     | `rm .Git/hooks/pre-commit`       |
+
+## Re-enabling Hooks
+
+After you're done working or ready to validate your code:
+
+```bash
+# Re-enable pre-commit hook
+./scripts/setup-hooks.sh
+
+# Verify it's now executable
+ls -la .Git/hooks/pre-commit
+# Should show: -rwxr-xr-x
+```
+
+If you disabled the hook, run the setup script again to re-enable it.
+
+**Best Practice**: Always re-enable hooks before pushing to avoid CI failures.
+
+## Troubleshooting
+
+### "shellcheck: command not found"
+
+The hook warned about this but allowed the commit. Install shellcheck (see Requirements section).
+
+### Hook not running
+
+Verify it's executable:
+
+```bash
+ls -la .Git/hooks/pre-commit
+# Should show: -rwxr-xr-x (executable)
+```
+
+If not executable, run:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
+### Commit blocked by hook, but I don't see the error
+
+The error output may have been cut off. Run shellcheck manually:
+
+```bash
+shellcheck <your-file>.sh
+```
+
+## CI pipeline (super-linter) versus pre-commit
+
+GitHub Actions runs **super-linter/slim@v7** (workflow: `.github/workflows/lint-extras.yaml`). Among the enabled linters, the following map directly to local tooling:
+
+| CI (super-linter) | What it is | Local equivalent in `scripts/hooks/pre-commit` |
+| ----------------- | ----------- | ----------------------------------------------- |
+| **MARKDOWN** | [markdownlint](https://github.com/DavidAnson/markdownlint) rules on `*.md` | `markdownlint -c .markdownlint.yaml <file>` (same rules as super-linter v7 template) on each **staged** `.md` file |
+| **MARKDOWN_PRETTIER** | [Prettier](https://prettier.io/) check on `*.md` | `npx prettier@3.5.3 --check <file>` on each staged `.md` file (same major as the image used in CI) |
+| **NATURAL_LANGUAGE** | textlint terminology rules | **Not** run in the hook; **CI only** unless you run textlint or super-linter yourself |
+
+YAML re-linting is covered locally with `yamllint`; the workflow sets `VALIDATE_YAML: false` and relies on the separate yamllint workflow where applicable—follow repository CI for the authoritative set.
+
+### Why MARKDOWN / MARKDOWN_PRETTIER can fail in CI even when the hook did not stop you
+
+1. **Staged files only** — The hook lints Markdown that is **staged** for the commit. Unstaged edits, fixes done after commit, or files changed only on the remote branch are still validated in CI for the pull request.
+2. **Missing local tools** — If `markdownlint` or `npx` (Node.js) is not installed, the hook prints a warning and **skips** that check. Other tools (for example shellcheck) can still run, so the commit may succeed without any Markdown validation.
+3. **`git commit --no-verify`** — Skips the entire hook; CI still runs.
+4. **NATURAL_LANGUAGE** — Terminology issues (for example “repo” vs “repository”) are **not** caught by the hook; they appear in CI until you fix them or run textlint/super-linter locally.
+5. **Scope** — CI validates the changes in the PR branch; a file you rarely touch can fail the first time it is included in a PR.
+
+### Commands to mirror CI before pushing
+
+From the repository root, on the same files you are about to push:
+
+```bash
+npx --yes prettier@3.5.3 --check "**/*.md"
+markdownlint "**/*.md"
+```
+
+Narrow the glob if needed. Fix issues with `npx prettier@3.5.3 --write <file>` and by editing for markdownlint.
+
+**Key takeaway:** Install **markdownlint**, **Node.js (`npx`)**, and the other tools listed under [Requirements](#requirements), run `./scripts/setup-hooks.sh`, and avoid `--no-verify` if you want local commits to match **MARKDOWN** and **MARKDOWN_PRETTIER** in CI. Add textlint or run super-linter locally for **NATURAL_LANGUAGE** parity.
+
+## Contributing
+
+When adding new shell scripts:
+
+1. Make sure they follow bash best practices
+2. Run shellcheck before committing
+3. The pre-commit hook will catch issues automatically
+4. If you need to commit without fixes, use `Git commit --no-verify` (but fix them before pushing)
+
+## References
+
+- [Shellcheck Wiki](https://www.shellcheck.net/)
+- [Bash Best Practices](https://mywiki.wooledge.org/BashGuide)
+- [Git Hooks Documentation](https://Git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)

--- a/docs/testing/ginkgo-flow-guide.md
+++ b/docs/testing/ginkgo-flow-guide.md
@@ -1,10 +1,13 @@
 # Ginkgo v2 Test Flow and Execution Guide
 
-This document explains how the Ginkgo v2 test framework is used in the CSI-Addons replication E2E test suite, covering test structure, execution flow, lifecycle management, and cleanup patterns.
+<!-- markdownlint-disable MD010 -->
+
+This document explains how the Ginkgo v2 test framework is used in the CSI-Addons replication end-to-end test suite, covering test structure, execution flow, lifecycle management, and cleanup patterns.
 
 ## 1. Overview
 
 **Ginkgo v2** is a mature BDD (Behavior-Driven Development) testing framework for Go that provides:
+
 - Expressive test organization with nested contexts
 - Flexible lifecycle hooks (BeforeSuite, AfterSuite, BeforeEach, AfterEach)
 - Detailed spec reporting with state tracking
@@ -29,11 +32,12 @@ import (
 // TestReplicationE2E is the entry point called by `go test`
 func TestReplicationE2E(t *testing.T) {
 	RegisterFailHandler(Fail)      // Route Ginkgo failures to Go test failures
-	RunSpecs(t, "Replication E2E Suite")  // Execute all registered specs
+	RunSpecs(t, "Replication end-to-end Suite")  // Execute all registered specs
 }
 ```
 
-**Purpose**: 
+**Purpose**:
+
 - `RegisterFailHandler(Fail)` tells Ginkgo to call `Fail()` when an assertion fails
 - `RunSpecs(t, description)` scans the package for registered `Describe` blocks and executes them
 
@@ -50,6 +54,7 @@ var _ = Describe("EnableVolumeReplication", func() { /* ... */ })
 ```
 
 **Timing**:
+
 1. Go calls `init()` functions → package variables are initialized
 2. Init-time `var _` statements execute → Ginkgo blocks register
 3. `TestReplicationE2E(t)` is called → RunSpecs executes all registered blocks
@@ -65,7 +70,7 @@ var _ = BeforeSuite(func() {
 	Logf("[SETUP]", "checking USE_EXISTING_CLUSTER")
 	useExistingCluster = os.Getenv("USE_EXISTING_CLUSTER") == "true"
 	if !useExistingCluster {
-		Skip("Replication E2E suite requires USE_EXISTING_CLUSTER=true")
+		Skip("Replication end-to-end suite requires USE_EXISTING_CLUSTER=true")
 	}
 
 	// Load kubeconfig and create Kubernetes clients
@@ -76,7 +81,7 @@ var _ = BeforeSuite(func() {
 	// One-time environment detection
 	Logf("[SETUP]", "detecting StorageClass and provisioner")
 	testEnv := GetTestEnv()
-	
+
 	// Detect NetworkFence support once
 	isSupported := HasNetworkFenceSupport(context.Background(), k8sClient, testEnv.Provisioner)
 	networkFenceSupportCached = &isSupported
@@ -84,6 +89,7 @@ var _ = BeforeSuite(func() {
 ```
 
 **Key behaviors**:
+
 - **Failure**: If BeforeSuite fails, entire suite is skipped
 - **Skip**: If Skip() is called, entire suite is skipped (with reason logged)
 - **Isolation**: Each call to `Expect()` can fail and stop BeforeSuite
@@ -102,6 +108,7 @@ var _ = ReportAfterEach(func(report types.SpecReport) {
 ```
 
 **SpecReport fields**:
+
 - `FullText()`: Complete spec path (e.g., "EnableVolumeReplication L1-E-001 Enable snapshot mode")
 - `State`: Enum (Passed, Failed, Skipped, Pending, Interrupted)
 - `RunTime`: Time from spec start to completion
@@ -114,7 +121,7 @@ var _ = ReportAfterEach(func(report types.SpecReport) {
 Executes **once after all specs complete**, with full test run information:
 
 ```go
-var _ = ReportAfterSuite("Replication E2E detailed summary", func(report types.Report) {
+var _ = ReportAfterSuite("Replication end-to-end detailed summary", func(report types.Report) {
 	// Report contains:
 	// - report.SpecReports: array of all SpecReport objects
 	// - report.SuiteDescription, report.SuitePath
@@ -126,12 +133,12 @@ var _ = ReportAfterSuite("Replication E2E detailed summary", func(report types.R
 	var passedSpecs, failedSpecs, skippedSpecs []*types.SpecReport
 	for i, spec := range report.SpecReports {
 		fullText := strings.TrimSpace(spec.FullText())
-		
+
 		// Skip lifecycle hooks and internal capability checks
 		if fullText == "" { continue }
 		if strings.Contains(fullText, "[BeforeSuite]") { continue }
 		if strings.Contains(fullText, "[AfterSuite]") { continue }
-		
+
 		if spec.State == types.SpecStatePassed {
 			passedSpecs = append(passedSpecs, &report.SpecReports[i])
 		} else if spec.State == types.SpecStateFailed {
@@ -146,12 +153,12 @@ var _ = ReportAfterSuite("Replication E2E detailed summary", func(report types.R
 	for _, spec := range passedSpecs {
 		fmt.Fprintf(GinkgoWriter, "  [✅] %s (%s)\n", spec.FullText(), spec.RunTime)
 	}
-	
+
 	fmt.Fprintf(GinkgoWriter, "\n=== FAILED (%d) ===\n", len(failedSpecs))
 	for _, spec := range failedSpecs {
 		fmt.Fprintf(GinkgoWriter, "  [❌] %s: %s\n", spec.FullText(), spec.Failure.Message)
 	}
-	
+
 	fmt.Fprintf(GinkgoWriter, "\n=== SKIPPED (%d) ===\n", len(skippedSpecs))
 	for _, spec := range skippedSpecs {
 		fmt.Fprintf(GinkgoWriter, "  [⏭️] %s (%s)\n", spec.FullText(), spec.SkipReason)
@@ -197,11 +204,13 @@ var _ = Describe("EnableVolumeReplication", func() {
 ```
 
 **Important distinction**:
+
 - **Init time** (during `go test` startup): Describe blocks execute to register specs
 - **Execution time** (during test run): It blocks execute, By blocks log progress
 
 **FullText generation**:
-```
+
+```plaintext
 EnableVolumeReplication → L1-E-001: Enable snapshot mode → should create...
 ↑                       ↑                                 ↑
 Outer Describe          Inner Describe                    It block
@@ -211,14 +220,14 @@ Outer Describe          Inner Describe                    It block
 
 ### 4.1 Overall Suite Execution Timeline
 
-```
+```plaintext
 go test ./test/e2e/replication/...
         │
         ▼
 ┌─────────────────────────────────────┐
 │  Test Function Execution Begins     │  ← TestReplicationE2E(t *testing.T)
 │  RegisterFailHandler(Fail)          │  ← Gomega assertion handler
-│  RunSpecs(t, "Replication E2E...")  │  ← Ginkgo discovers and runs specs
+│  RunSpecs(t, "Replication end-to-end...")  │  ← Ginkgo discovers and runs specs
 └─────────────────────────────────────┘
         │
         ▼
@@ -279,7 +288,7 @@ Exit test with results
 
 ### 4.2 Detailed Spec Execution (Single Test Case)
 
-```
+```plaintext
 It("Enable snapshot mode replication", func() {
     // Test body executes here
 })
@@ -336,7 +345,7 @@ It("Enable snapshot mode replication", func() {
 
 ### 4.3 DeferCleanup Execution (LIFO Order)
 
-```
+```plaintext
 During test execution, cleanup functions are registered with DeferCleanup():
 
 It("scenario", func() {
@@ -388,10 +397,10 @@ CLEANUP COMPLETE
 
 ### 4.4 Describe Block Hierarchy
 
-```
+```plaintext
 Root Level
     │
-    Describe("Replication E2E", func() {
+    Describe("Replication end-to-end", func() {
         │
         Describe("EnableVolumeReplication API", func() {
             │
@@ -429,7 +438,8 @@ Root Level
 ### 4.5 Hook Execution Order (Edge Cases)
 
 **Case 1: Test PASSES**
-```
+
+```plaintext
 ┌─────────────────────────────────────┐
 │ [1] Spec runs (all By blocks)       │
 │ [2] DeferCleanup handlers (LIFO)    │
@@ -439,7 +449,8 @@ Root Level
 ```
 
 **Case 2: Test FAILS (Expect assertion)**
-```
+
+```plaintext
 ┌─────────────────────────────────────┐
 │ [1] Spec runs (until Expect fails)  │
 │ [2] DeferCleanup handlers (LIFO)    │
@@ -451,7 +462,8 @@ Root Level
 ```
 
 **Case 3: Test PANICS**
-```
+
+```plaintext
 ┌─────────────────────────────────────┐
 │ [1] Spec runs (until panic)         │
 │ [2] Panic caught by Ginkgo          │
@@ -518,7 +530,8 @@ It("L1-E-001: Enable snapshot mode", func() {
 ```
 
 **Output**:
-```
+
+```plaintext
 2026-03-10 10:15:22.123 [SPEC] By: L1-E-001: Create namespace
 2026-03-10 10:15:23.456 [SPEC] By: L1-E-001: Creating PVC
 2026-03-10 10:15:24.789 [SPEC] By: L1-E-001: Creating VolumeReplicationClass
@@ -554,6 +567,7 @@ It("should validate volume replication status", func() {
 ```
 
 **Matchers used in tests**:
+
 - `Equal(value)` - exact equality
 - `ContainElement(matcher)` - array/slice contains matching element
 - `MatchFields(ignoreExtras, fields)` - struct field matching
@@ -582,13 +596,13 @@ It("should create and cleanup volume replication", func() {
 		cleanupCtx := context.Background()
 		Logf("[CLEANUP]", "deleting VolumeReplication")
 		DeleteVolumeReplicationWithCleanup(cleanupCtx, k8sClient, vr)
-		
+
 		Logf("[CLEANUP]", "deleting VolumeReplicationClass")
 		DeleteVolumeReplicationClassWithCleanup(cleanupCtx, k8sClient, vrc)
-		
+
 		Logf("[CLEANUP]", "deleting PVC")
 		DeletePVCWithCleanup(cleanupCtx, k8sClient, pvc)
-		
+
 		Logf("[CLEANUP]", "deleting namespace")
 		DeleteNamespace(cleanupCtx, k8sClient, ns)
 	})
@@ -611,20 +625,22 @@ It("should create and cleanup volume replication", func() {
 ```
 
 **Key behaviors**:
+
 - **Multiple DeferCleanup calls**: Execute in LIFO order (last registered = first executed)
 - **On failure**: Cleanup still runs even if spec fails
 - **On panic**: Cleanup still runs even if spec panics
 - **Nested contexts**: Each context.Background() is independent
 
 **Cleanup function structure**:
+
 ```go
 DeferCleanup(func() {
 	// Create fresh context for cleanup
 	cleanupCtx := context.Background()
-	
+
 	// Use helper with logging
 	DeleteVolumeReplicationWithCleanup(cleanupCtx, k8sClient, vr)
-	
+
 	// Continues even if deletion takes time or has errors
 })
 ```
@@ -636,27 +652,27 @@ The test suite provides cleanup helpers that handle timeout and logging:
 ```go
 func DeleteVolumeReplicationWithCleanup(ctx context.Context, k8sClient client.Client, vr *replicationv1alpha1.VolumeReplication) {
 	Logf("[CLEANUP]", "deleting VolumeReplication %s/%s", vr.Namespace, vr.Name)
-	
+
 	// Remove finalizers if present
 	if controllerutil.ContainsFinalizer(vr, "replication.storage.openshift.io/finalizer") {
 		controllerutil.RemoveFinalizer(vr, "replication.storage.openshift.io/finalizer")
 		_ = k8sClient.Update(ctx, vr)
 	}
-	
+
 	// Delete with timeout
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	err := k8sClient.Delete(ctx, vr)
 	if err != nil && !errors.IsNotFound(err) {
 		Logf("[CLEANUP]", "error deleting VR: %v (continuing)", err)
 	}
-	
+
 	// Wait for deletion with eventual consistent check
 	Eventually(func() error {
 		return k8sClient.Get(ctx, client.ObjectKey{Namespace: vr.Namespace, Name: vr.Name}, vr)
 	}, 10*time.Second, 500*time.Millisecond).Should(MatchError(errors.IsNotFound))
-	
+
 	Logf("[CLEANUP]", "VolumeReplication deleted successfully")
 }
 ```
@@ -665,7 +681,7 @@ func DeleteVolumeReplicationWithCleanup(ctx context.Context, k8sClient client.Cl
 
 ### 6.1 Registration Phase (Init Time)
 
-```
+```plaintext
 go test ./test/e2e/replication
         ↓
 Go runtime loads package
@@ -689,7 +705,7 @@ RunSpecs() is called → execution phase begins
 
 ### 6.2 Execution Phase (During Test Run)
 
-```
+```plaintext
 RunSpecs() begins
         ↓
 BeforeSuite() runs once
@@ -734,7 +750,8 @@ var _ = FDescribe("EnableVolumeReplication", func() {
 ```
 
 **Pattern matching**:
-- Regex support: `GINKGO_FOCUS="L1-E-00[123]"` matches L1-E-001, L1-E-002, L1-E-003
+
+- Regular expression support: `GINKGO_FOCUS="L1-E-00[123]"` matches L1-E-001, L1-E-002, L1-E-003
 - Case sensitive: `GINKGO_FOCUS="enable"` does NOT match "EnableVolumeReplication"
 - Partial match: `GINKGO_FOCUS="E-001"` matches "L1-E-001" anywhere in spec name
 
@@ -772,15 +789,15 @@ It("should validate multiple replication scenarios", func() {
 
 	for _, tc := range testCases {
 		By(fmt.Sprintf("Testing: %s", tc.name))
-		
+
 		// Create VolumeReplication with test case parameters
 		vrc := CreateVolumeReplicationClass(ctx, k8sClient, "vrc", provisioner, secret, secretNs, tc.mirroringMode)
-		
+
 		// Register cleanup before assertions (so it runs even if assertion fails)
 		DeferCleanup(func() {
 			DeleteVolumeReplicationClassWithCleanup(context.Background(), k8sClient, vrc)
 		})
-		
+
 		// Validate
 		if tc.expectError {
 			Expect(vrc.Spec.MirroringMode).NotTo(Equal("invalid"))
@@ -793,7 +810,8 @@ It("should validate multiple replication scenarios", func() {
 ```
 
 **Output**:
-```
+
+```plaintext
 2026-03-10 10:15:22.123 [SPEC] By: Testing: snapshot mode with 1m interval
 2026-03-10 10:15:23.456 [SPEC] By: Testing: journal mode with 5m interval
 2026-03-10 10:15:24.789 [SPEC] By: Testing: invalid mirroring mode
@@ -811,7 +829,7 @@ Describe("EnableVolumeReplication", func() {
 			DeferCleanup(func() {
 				DeleteVolumeReplicationClassWithCleanup(context.Background(), k8sClient, vrc)
 			})
-			
+
 			if tc.expectError {
 				Expect(vrc.Spec.MirroringMode).NotTo(Equal("invalid"))
 			} else {
@@ -843,7 +861,8 @@ Logf("[CLEANUP]", "deleting PVC %s/%s", pvc.Namespace, pvc.Name)
 ```
 
 **Output format**:
-```
+
+```plaintext
 2026-03-10 10:15:22.123 [SETUP] creating Kubernetes client
 2026-03-10 10:15:23.456 [PVC] ns=test-ns name=pvc-1 phase=Bound
 2026-03-10 10:15:24.789 [VR] replicating=true degraded=false
@@ -852,15 +871,15 @@ Logf("[CLEANUP]", "deleting PVC %s/%s", pvc.Namespace, pvc.Name)
 
 ## 9. Summary Table: Ginkgo Execution Flow
 
-| Phase | When | What | Registrations | Timing |
-|-------|------|------|----------------|--------|
-| **Init** | `go test` startup | Package initialization | var _ = BeforeSuite(), Describe(), It(), DeferCleanup() registered | Synchronous, once |
-| **BeforeSuite** | Before any specs | Cluster setup, client creation | Runs once for entire suite | If fails, skip all specs |
-| **BeforeEach** | Before each spec | Per-test setup | Runs for each It block | If fails, skip that spec |
-| **It (Body)** | During test execution | Test assertions | Test logic | Runs once per spec |
-| **By** | During It execution | Progress logging | Not execution, just logging | Synchronous output |
-| **DeferCleanup** | When spec exits | Cleanup registration (at init time) + cleanup execution (after spec) | Registered during It execution | LIFO order, always runs |
-| **ReportAfterEach** | After each spec | Log progress, metrics | Runs for each spec completion | Has access to SpecReport |
-| **AfterEach** | After each spec | Per-test cleanup | Optional hook | Runs after spec + report |
-| **ReportAfterSuite** | After all specs | Print summary, aggregate metrics | Runs once after all specs | Has access to full Report |
-| **AfterSuite** | After all specs | Final cleanup | Optional hook | If fails, marks suite as failed |
+| Phase                | When                  | What                                                                 | Registrations                                                       | Timing                          |
+| -------------------- | --------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| **Init**             | `go test` startup     | Package initialization                                               | var \_ = BeforeSuite(), Describe(), It(), DeferCleanup() registered | Synchronous, once               |
+| **BeforeSuite**      | Before any specs      | Cluster setup, client creation                                       | Runs once for entire suite                                          | If fails, skip all specs        |
+| **BeforeEach**       | Before each spec      | Per-test setup                                                       | Runs for each It block                                              | If fails, skip that spec        |
+| **It (Body)**        | During test execution | Test assertions                                                      | Test logic                                                          | Runs once per spec              |
+| **By**               | During It execution   | Progress logging                                                     | Not execution, just logging                                         | Synchronous output              |
+| **DeferCleanup**     | When spec exits       | Cleanup registration (at init time) + cleanup execution (after spec) | Registered during It execution                                      | LIFO order, always runs         |
+| **ReportAfterEach**  | After each spec       | Log progress, metrics                                                | Runs for each spec completion                                       | Has access to SpecReport        |
+| **AfterEach**        | After each spec       | Per-test cleanup                                                     | Optional hook                                                       | Runs after spec + report        |
+| **ReportAfterSuite** | After all specs       | Print summary, aggregate metrics                                     | Runs once after all specs                                           | Has access to full Report       |
+| **AfterSuite**       | After all specs       | Final cleanup                                                        | Optional hook                                                       | If fails, marks suite as failed |

--- a/docs/testing/replication-e2e-suite.md
+++ b/docs/testing/replication-e2e-suite.md
@@ -1,8 +1,8 @@
-# Replication E2E Test Suite
+# Replication end-to-end Test Suite
 
-The replication E2E suite runs cluster-facing tests that create VolumeReplication and VolumeReplicationClass resources and assert on their status. It implements scenarios from the Layer-1 CSI Replication Add-on Test Matrix.
+The replication end-to-end suite runs cluster-facing tests that create VolumeReplication and VolumeReplicationClass resources and assert on their status. It implements scenarios from the Layer-1 CSI Replication Add-on Test Matrix.
 
-**This document is the source of truth** for the replication E2E test plan. The following external documents were used as references:
+**This document is the source of truth** for the replication end-to-end test plan. The following external documents were used as references:
 
 - [Layer-1 VolumeReplication Test Matrix (layer-1-vr-tests.md)](https://github.com/nadavleva/csi_replication_certs/blob/main/docs/layer-1-vr-tests.md)
 - [Layer-1 VRG Test Matrix (layer-1-vrg-tests.md)](https://github.com/nadavleva/csi_replication_certs/blob/main/docs/layer-1-vrg-tests.md)
@@ -11,29 +11,35 @@ The replication E2E suite runs cluster-facing tests that create VolumeReplicatio
 ## Location
 
 - **Package**: `test/e2e/replication/`
-- **Scenarios**: EnableVolumeReplication (L1-E-001 through L1-E-009), DisableVolumeReplication (L1-DIS-001, L1-DIS-002), GetVolumeReplicationInfo (L1-INFO-001, L1-INFO-005, L1-INFO-008, L1-INFO-011, L1-INFO-012, L1-INFO-013, L1-INFO-014), and Full DR (two clusters). L1-E-003 blocks the peer via **iptables** (default) or **NetworkFence** (`E2E_FAULT_INJECTOR`) so EnableVolumeReplication fails, then unfences and asserts success. L1-DIS-002 requires DR1_CONTEXT and DR2_CONTEXT; tests that need two clusters skip with a log when not configured.
+- **Scenarios**: EnableVolumeReplication (L1-E-001 through L1-E-009), DisableVolumeReplication (L1-DIS-001, L1-DIS-002),
+  GetVolumeReplicationInfo (L1-INFO-001, L1-INFO-005, L1-INFO-008, L1-INFO-011, L1-INFO-012, L1-INFO-013, L1-INFO-014), and Full DR (two clusters).
+  L1-E-003 blocks the peer via **iptables** (default) or **NetworkFence** (`E2E_FAULT_INJECTOR`) so EnableVolumeReplication fails, then unfences and asserts success.
+  L1-DIS-002 requires `DR1_CONTEXT` and `DR2_CONTEXT`; tests that need two clusters skip with a log when not configured.
 
 ## Cleanup
 
-**On every run:** The run script registers an **EXIT trap** that runs `clean-replication-e2e-resources.sh` when the script exits (success, failure, or panic/timeout). So PVCs, VRs, test VRCs, and e2e-replication-* namespaces are cleaned even if tests panic or hit the test timeout.
+**On every run:** The run script registers an **EXIT trap** that runs `clean-replication-end-to-end-resources.sh` when the script exits (success, failure, or panic/timeout). So PVCs, VRs, test VRCs, and end-to-end-replication-\* namespaces are cleaned even if tests panic or hit the test timeout.
 
 **Before a run:** If a previous run left resources stuck (e.g. Terminating PVCs or VRs), you can clean them manually first:
 
 ```bash
-make clean-replication-e2e
+make clean-replication-end-to-end
 # or
-./hack/clean-replication-e2e-resources.sh
+./hack/clean-replication-end-to-end-resources.sh
 ```
 
 To preview what would be deleted without making changes:
 
 ```bash
-./hack/clean-replication-e2e-resources.sh --dry-run
+./hack/clean-replication-end-to-end-resources.sh --dry-run
 ```
 
-The script removes finalizers from VolumeReplications and PVCs in `e2e-replication-*` namespaces, deletes those resources plus any VolumeSnapshots, deletes the namespaces, and deletes test-created VolumeReplicationClasses (names starting with `vrc-snapshot-`, `vrc-journal-`, etc.).
+The script removes finalizers from VolumeReplications and PVCs in `end-to-end-replication-*` namespaces, deletes those resources plus any VolumeSnapshots, deletes the namespaces, and deletes test-created VolumeReplicationClasses (names starting with `vrc-snapshot-`, `vrc-journal-`, etc.).
 
-**Planned enhancement:** Create a failure report (PVC, VolumeReplication, VolumeReplicationGroup, events, pod logs from test namespaces and `REPLICATION_SECRET_NAMESPACE`) **before** cleanup on test failure, and store it under `Logs/<run-folder>/`. See [.github/ISSUE_TEMPLATE/replication-e2e-failure-report.md](../../.github/ISSUE_TEMPLATE/replication-e2e-failure-report.md) for the full issue description.
+**Planned enhancement:** Create a failure report (PVC, VolumeReplication, VolumeReplicationGroup, events, pod logs from test namespaces and
+`REPLICATION_SECRET_NAMESPACE`) **before** cleanup on test failure, and store it under `Logs/<run-folder>/`.
+See [.github/ISSUE_TEMPLATE/replication-end-to-end-failure-report.md](../../.github/ISSUE_TEMPLATE/replication-end-to-end-failure-report.md)
+for the full issue description.
 
 ## Prerequisites
 
@@ -44,7 +50,7 @@ The script removes finalizers from VolumeReplications and PVCs in `e2e-replicati
 
 ## Running the suite
 
-### Run all replication E2E tests
+### Run all replication end-to-end tests
 
 ```bash
 make test-replication-e2e
@@ -81,21 +87,26 @@ make test-replication-e2e GINKGO_FOCUS="L1-E-001"
 
 ### Optional environment variables
 
-| Variable                       | Description                                                                 | Default        |
-|--------------------------------|-----------------------------------------------------------------------------|----------------|
-| `GINKGO_FOCUS`                 | Ginkgo focus expression to run only matching specs                         | (run all)      |
-| `E2E_FAULT_INJECTOR`           | Fault injection mechanism for network fencing tests (L1-E-003): `networkfence` (CSI-Addons NetworkFence CRDs), `iptables` (iptables-based blocking), or `none` (no fault injection) | `iptables`     |
-| `INSTALL_CRDS`                 | Set to `true` to install CRDs from `deploy/controller/crds.yaml` if missing | `false`        |
-| `STORAGE_CLASS`                | StorageClass name used for test PVCs. Not auto-detected from the cluster; defaults match typical Rook-Ceph block storage. | `rook-ceph-block` |
-| `CSI_PROVISIONER`              | VolumeReplicationClass provisioner; must match CSIAddonsNode `spec.driver.name`. Not auto-detected; default matches Rook-Ceph RBD. | `rook-ceph.rbd.csi.ceph.com` |
-| `REPLICATION_SECRET_NAME`      | Name of existing secret for replication (use with `REPLICATION_SECRET_NAMESPACE`) | (create per-namespace secret) |
-| `REPLICATION_SECRET_NAMESPACE` | Namespace of existing replication secret                                   | (create per-namespace secret) |
-| `REPLICATION_POLL_TIMEOUT`     | Timeout in seconds for waiting on Replicating=True (and error conditions)  | `300` |
-| `REPLICATION_TEST_TIMEOUT`     | Go test timeout for the entire suite (e.g. `30m`, `60m`). Prevents "test timed out after 10m0s". | `30m` |
-| `DR1_CONTEXT`                  | Kubeconfig context name for primary cluster (DR1). Set with `DR2_CONTEXT` for full-DR mode. | (unset) |
-| `DR2_CONTEXT`                  | Kubeconfig context name for secondary cluster (DR2). Set with `DR1_CONTEXT` for full-DR mode. | (unset) |
-| `FENCE_CIDRS`                  | Comma-separated CIDRs for L1-E-003. For **networkfence**, if unset, CIDRs come from CSIAddonsNode `status.networkFenceClientStatus`, then node InternalIPs. For **iptables**, if unset, node InternalIPs are used (no NetworkFenceClass required). | (CSIAddonsNode or node IPs) |
-| `FENCE_CLUSTER_ID`             | ClusterID for Ceph CSI NetworkFenceClass (required for Ceph/Rook). If unset, inferred from `REPLICATION_SECRET_NAMESPACE` when provisioner contains "ceph". | (inferred from secret namespace) |
+| Variable                         | Description                                                                                                                                                                                                                                                                                                     | Default                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `GINKGO_FOCUS`                   | Ginkgo focus expression to run only matching specs                                                                                                                                                                                                                                                              | (run all)                                      |
+| `E2E_FAULT_INJECTOR`             | Fault injection mechanism for network fencing tests (L1-E-003): `networkfence` (CSI-Addons NetworkFence CRDs), `iptables` (iptables-based blocking), or `none` (no fault injection)                                                                                                                             | `iptables`                                     |
+| `INSTALL_CRDS`                   | Set to `true` to install CRDs from `deploy/controller/crds.yaml` if missing                                                                                                                                                                                                                                     | `false`                                        |
+| `STORAGE_CLASS`                  | StorageClass name used for test PVCs. Not auto-detected from the cluster; defaults match typical Rook-Ceph block storage.                                                                                                                                                                                       | `rook-ceph-block`                              |
+| `CSI_PROVISIONER`                | VolumeReplicationClass provisioner; must match CSIAddonsNode `spec.driver.name`. Not auto-detected; default matches Rook-Ceph RBD.                                                                                                                                                                              | `rook-ceph.rbd.csi.ceph.com`                   |
+| `REPLICATION_SECRET_NAME`        | Name of existing secret for replication (use with `REPLICATION_SECRET_NAMESPACE`)                                                                                                                                                                                                                               | (create per-namespace secret)                  |
+| `REPLICATION_SECRET_NAMESPACE`   | Namespace of existing replication secret                                                                                                                                                                                                                                                                        | (create per-namespace secret)                  |
+| `REPLICATION_POLL_TIMEOUT`       | Timeout in seconds for waiting on Replicating=True (and error conditions)                                                                                                                                                                                                                                       | `300`                                          |
+| `REPLICATION_TEST_TIMEOUT`       | Go test timeout for the entire suite (e.g. `30m`, `60m`). Prevents "test timed out after 10m0s".                                                                                                                                                                                                                | `30m`                                          |
+| `DR1_CONTEXT`                    | Kubeconfig context name for primary cluster (DR1). Set with `DR2_CONTEXT` for full-DR mode.                                                                                                                                                                                                                     | (unset)                                        |
+| `DR2_CONTEXT`                    | Kubeconfig context name for secondary cluster (DR2). Set with `DR1_CONTEXT` for full-DR mode.                                                                                                                                                                                                                   | (unset)                                        |
+| `FENCE_CIDRS`                    | Comma-separated CIDRs for fencing tests. For **networkfence**, if unset: CSIAddonsNode `status.networkFenceClientStatus`, then node InternalIPs. For **iptables**, if unset: service/backend discovery (`FENCE_TARGET_SERVICES`, `FENCE_AUTO_ENDPOINT_NAMESPACES`); raw node IPs are not targets unless listed. | (discovered or node IPs for NetworkFence only) |
+| `FENCE_TARGET_SERVICES`          | Comma-separated `namespace/service` keys (iptables). Resolves backend IPs via Endpoints and EndpointSlices on the **fencing** cluster for single-cluster discovery; if `FENCE_PEER_SERVICES` is unset, the same keys are used for peer lookup in full-DR flows.                                                 | (unset)                                        |
+| `FENCE_PEER_SERVICES`            | Same format as `FENCE_TARGET_SERVICES`. When set in full-DR mode, backends are resolved on the **peer** cluster (`DR2_CONTEXT` client) for iptables peer fencing; if unset, `FENCE_TARGET_SERVICES` keys are reused.                                                                                            | (unset; reuse `FENCE_TARGET_SERVICES`)         |
+| `FENCE_AUTO_ENDPOINT_NAMESPACES` | Comma-separated namespace names. When set (iptables), the suite auto-discovers Endpoint/EndpointSlice backends in those namespaces if `FENCE_TARGET_SERVICES` did not yield usable CIDRs.                                                                                                                       | (unset)                                        |
+| `FENCE_CLUSTER_ID`               | ClusterID for Ceph CSI NetworkFenceClass (required for Ceph/Rook). If unset, inferred from `REPLICATION_SECRET_NAMESPACE` when provisioner contains "ceph".                                                                                                                                                     | (inferred from secret namespace)               |
+| `IPTABLES_IMAGE`                 | Passed through by `hack/run-replication-e2e.sh`; exported to tests as `E2E_IPTABLES_IMAGE` for the iptables DaemonSet image.                                                                                                                                                                                    | `csi-addons/iptables-manager:latest`           |
+| `REPORTS_DIR`                    | Directory for JUnit and progress reports from the replication suite (see `suite_test.go`). If unset, the suite picks a path under the project root.                                                                                                                                                             | (auto)                                         |
 
 **Fault injection method (E2E_FAULT_INJECTOR):** L1-E-003 tests peer unreachability by blocking network connectivity. The test suite supports three fault injection backends:
 
@@ -116,7 +127,7 @@ E2E_FAULT_INJECTOR=networkfence make test-replication-e2e GINKGO_FOCUS="L1-E-003
 E2E_FAULT_INJECTOR=none make test-replication-e2e
 ```
 
-**L1-E-003 NetworkFence (Ceph CSI):** The Ceph CSI driver requires `clusterID` in NetworkFenceClass parameters for network fencing. For Rook, use the cluster namespace (e.g. `rook-ceph`). The e2e suite adds this automatically when the provisioner contains "ceph":
+**L1-E-003 NetworkFence (Ceph CSI):** The Ceph CSI driver requires `clusterID` in NetworkFenceClass parameters for network fencing. For Rook, use the cluster namespace (e.g. `rook-ceph`). The end-to-end suite adds this automatically when the provisioner contains "ceph":
 
 ```yaml
 parameters:
@@ -127,9 +138,13 @@ parameters:
 
 Set `FENCE_CLUSTER_ID` to override the inferred value.
 
-**VRC and timeouts:** Tests create their own VolumeReplicationClasses (e.g. `vrc-snapshot-<ns>`, `vrc-journal-<ns>`) with **scheduling interval 1m** for snapshot mode so the first replication cycle can complete within the wait window. They do not use existing cluster VRCs (e.g. `vrc-5m`). If Replicating=True is not set within the timeout (e.g. journal mode or a slow cluster), increase **`REPLICATION_POLL_TIMEOUT`** (seconds). Test output includes step-by-step progress and per-poll VR status (`state`, `conditions`) when waiting.
+**VRC and timeouts:** Tests create their own VolumeReplicationClasses (e.g. `vrc-snapshot-<ns>`, `vrc-journal-<ns>`) with **scheduling interval 1m** for snapshot mode so the first replication cycle can complete within the wait window.
+They do not use existing cluster VRCs (e.g. `vrc-5m`). If Replicating=True is not set within the timeout (e.g. journal mode or a slow cluster), increase **`REPLICATION_POLL_TIMEOUT`** (seconds).
+Test output includes step-by-step progress and per-poll VR status (`state`, `conditions`) when waiting.
 
-**Replication secret:** The Ceph RBD CSI driver expects the secret referenced by the VolumeReplicationClass to contain **`userID`** and **`userKey`** in its `data`. If you do **not** set `REPLICATION_SECRET_NAME` and `REPLICATION_SECRET_NAMESPACE`, the suite creates a per-test secret with placeholder `userID`/`userKey` so the driver does not return “missing ID field 'userID' in secrets”. For a real Ceph cluster (e.g. Rook), use the existing RBD CSI secret by setting both variables. Typical Rook secrets in `rook-ceph`:
+**Replication secret:** The Ceph RBD CSI driver expects the secret referenced by the VolumeReplicationClass to contain **`userID`** and **`userKey`** in its `data`.
+If you do **not** set `REPLICATION_SECRET_NAME` and `REPLICATION_SECRET_NAMESPACE`, the suite creates a per-test secret with placeholder `userID`/`userKey` so the driver does not return “missing ID field 'userID' in secrets”.
+For a real Ceph cluster (e.g. Rook), use the existing RBD CSI secret by setting both variables. Typical Rook secrets in `rook-ceph`:
 
 - **`rook-csi-rbd-provisioner`** – used by the RBD CSI controller (recommended for replication).
 - `rook-csi-rbd-node` – used by the RBD node plugin.
@@ -144,15 +159,15 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ### Overall Summary (March 10, 2026)
 
-| Metric | Value |
-|--------|-------|
-| **Total Specs** | 42 |
-| **Implementation Status** | ✅ **All VolumeReplication APIs fully implemented** |
-| **Passed (Full DR mode)** | 38+ |
-| **Skipped** | 5 (1 CSI behavior investigation + 4 infrastructure gaps) |
-| **Failed** | 0 |
-| **Total Test Cases** | ~75+ |
-| **Execution Duration** | ~45-50 minutes (full suite) |
+| Metric                    | Value                                                    |
+| ------------------------- | -------------------------------------------------------- |
+| **Total Specs**           | 42                                                       |
+| **Implementation Status** | ✅ **All VolumeReplication APIs fully implemented**      |
+| **Passed (Full DR mode)** | 38+                                                      |
+| **Skipped**               | 5 (1 CSI behavior investigation + 4 infrastructure gaps) |
+| **Failed**                | 0                                                        |
+| **Total Test Cases**      | ~75+                                                     |
+| **Execution Duration**    | ~45-50 minutes (full suite)                              |
 
 ### Implementation by API
 
@@ -160,19 +175,20 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## EnableVolumeReplication API (9 specs, 18 test cases)
 
-| Spec | Status | Description | Duration |
-|------|--------|-------------|----------|
-| **L1-E-001** + L1-INFO-001 | ✅ Implemented | Enable snapshot mode replication | ~6s |
-| **L1-E-002** + L1-INFO-001 | ✅ Implemented | Enable journal mode replication | ~6s |
-| **L1-E-003** + L1-INFO-005/001 | ✅ Implemented | Peer unreachable: iptables (default) or NetworkFence via `E2E_FAULT_INJECTOR` | ~180s |
-| **L1-E-004** + L1-INFO-012 | ✅ Implemented | Invalid schedulingInterval (error handling) | ~6s |
-| **L1-E-005** + L1-INFO-001 | ✅ Implemented | Idempotent enable (no-op on already-enabled) | ~6s |
-| **L1-E-006** + L1-INFO-013 | ✅ Implemented | Invalid secret reference (error handling) | ~6s |
-| **L1-E-007** + L1-INFO-011 | ✅ Implemented | Invalid mirroringMode (error handling) | ~6s |
-| **L1-E-008** + L1-INFO-001 | ✅ Implemented | Future schedulingStartTime (deferred replication) | ~6s |
-| **L1-E-009** + L1-INFO-014 | ✅ Implemented | Invalid schedulingStartTime format (error handling) | ~6s |
+| Spec                           | Status         | Description                                                                   | Duration |
+| ------------------------------ | -------------- | ----------------------------------------------------------------------------- | -------- |
+| **L1-E-001** + L1-INFO-001     | ✅ Implemented | Enable snapshot mode replication                                              | ~6s      |
+| **L1-E-002** + L1-INFO-001     | ✅ Implemented | Enable journal mode replication                                               | ~6s      |
+| **L1-E-003** + L1-INFO-005/001 | ✅ Implemented | Peer unreachable: iptables (default) or NetworkFence via `E2E_FAULT_INJECTOR` | ~180s    |
+| **L1-E-004** + L1-INFO-012     | ✅ Implemented | Invalid schedulingInterval (error handling)                                   | ~6s      |
+| **L1-E-005** + L1-INFO-001     | ✅ Implemented | Idempotent enable (no-op on already-enabled)                                  | ~6s      |
+| **L1-E-006** + L1-INFO-013     | ✅ Implemented | Invalid secret reference (error handling)                                     | ~6s      |
+| **L1-E-007** + L1-INFO-011     | ✅ Implemented | Invalid mirroringMode (error handling)                                        | ~6s      |
+| **L1-E-008** + L1-INFO-001     | ✅ Implemented | Future schedulingStartTime (deferred replication)                             | ~6s      |
+| **L1-E-009** + L1-INFO-014     | ✅ Implemented | Invalid schedulingStartTime format (error handling)                           | ~6s      |
 
 **Key Features:**
+
 - Creates VolumeReplicationClass with specified mirroring mode (snapshot/journal)
 - Monitors VolumeReplication status for `Replicating=True` and `Completed=True`
 - Tests both success and error scenarios with proper status conditions
@@ -183,17 +199,18 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## GetVolumeReplicationInfo API (10 specs, 10 test cases)
 
-| Spec | Status | Description | Duration |
-|------|--------|-------------|----------|
-| **L1-INFO-001** | ✅ Implemented | Successful replication info (Replicating=True) | Integrated with E-001, E-002, E-005, E-008 |
-| **L1-INFO-005** | ✅ Implemented | Error info when peer is unreachable | Integrated with E-003 |
-| **L1-INFO-008** | ✅ Implemented | Non-existent volume (error handling) | ~2s |
-| **L1-INFO-011** | ✅ Implemented | Invalid mirroringMode (error in conditions) | Integrated with E-007 |
-| **L1-INFO-012** | ✅ Implemented | Invalid schedulingInterval (error in conditions) | Integrated with E-004 |
-| **L1-INFO-013** | ✅ Implemented | Invalid secret (error in conditions) | Integrated with E-006 |
-| **L1-INFO-014** | ✅ Implemented | Invalid time format (error in conditions) | Integrated with E-009 |
+| Spec            | Status         | Description                                      | Duration                                   |
+| --------------- | -------------- | ------------------------------------------------ | ------------------------------------------ |
+| **L1-INFO-001** | ✅ Implemented | Successful replication info (Replicating=True)   | Integrated with E-001, E-002, E-005, E-008 |
+| **L1-INFO-005** | ✅ Implemented | Error info when peer is unreachable              | Integrated with E-003                      |
+| **L1-INFO-008** | ✅ Implemented | Non-existent volume (error handling)             | ~2s                                        |
+| **L1-INFO-011** | ✅ Implemented | Invalid mirroringMode (error in conditions)      | Integrated with E-007                      |
+| **L1-INFO-012** | ✅ Implemented | Invalid schedulingInterval (error in conditions) | Integrated with E-004                      |
+| **L1-INFO-013** | ✅ Implemented | Invalid secret (error in conditions)             | Integrated with E-006                      |
+| **L1-INFO-014** | ✅ Implemented | Invalid time format (error in conditions)        | Integrated with E-009                      |
 
 **Key Features:**
+
 - Returns VolumeReplication status with replication state, conditions, and timestamps
 - Handles healthy replication (Replicating=True, Degraded=False)
 - Handles error conditions with appropriate failure messages and status
@@ -203,20 +220,21 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## DisableVolumeReplication API (12 specs, 12 test cases)
 
-| Spec | Status | Description | Duration | Requirements |
-|------|--------|-------------|----------|--------------|
-| **L1-DIS-001** | ✅ Implemented | Disable active replication on primary | ~6s | Single cluster |
-| **L1-DIS-002** | ✅ Implemented | Disable active replication on secondary | ~31s | Full DR mode |
-| **L1-DIS-003** | ✅ Implemented | Idempotent disable (no VR on primary) | ~4s | Single cluster |
-| **L1-DIS-004** | ✅ Implemented | Idempotent disable (no VR on secondary) | ~4s | Full DR mode |
-| **L1-DIS-005** | ✅ Implemented | Disable with peer unreachable (force=false) | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
-| **L1-DIS-006** | ✅ Implemented | Disable with peer unreachable (force=true) | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
-| **L1-DIS-009** | ✅ Implemented | Force disable active replication (primary) | ~6s | Single cluster |
-| **L1-DIS-010** | ✅ Implemented | Force disable active replication (secondary) | ~31s | Full DR mode |
-| **L1-DIS-011** | ✅ Implemented | Force disable idempotent (no VR on primary) | ~4s | Single cluster |
-| **L1-DIS-012** | ✅ Implemented | Force disable idempotent (no VR on secondary) | ~4s | Full DR mode |
+| Spec           | Status         | Description                                   | Duration                      | Requirements           |
+| -------------- | -------------- | --------------------------------------------- | ----------------------------- | ---------------------- |
+| **L1-DIS-001** | ✅ Implemented | Disable active replication on primary         | ~6s                           | Single cluster         |
+| **L1-DIS-002** | ✅ Implemented | Disable active replication on secondary       | ~31s                          | Full DR mode           |
+| **L1-DIS-003** | ✅ Implemented | Idempotent disable (no VR on primary)         | ~4s                           | Single cluster         |
+| **L1-DIS-004** | ✅ Implemented | Idempotent disable (no VR on secondary)       | ~4s                           | Full DR mode           |
+| **L1-DIS-005** | ✅ Implemented | Disable with peer unreachable (force=false)   | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
+| **L1-DIS-006** | ✅ Implemented | Disable with peer unreachable (force=true)    | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
+| **L1-DIS-009** | ✅ Implemented | Force disable active replication (primary)    | ~6s                           | Single cluster         |
+| **L1-DIS-010** | ✅ Implemented | Force disable active replication (secondary)  | ~31s                          | Full DR mode           |
+| **L1-DIS-011** | ✅ Implemented | Force disable idempotent (no VR on primary)   | ~4s                           | Single cluster         |
+| **L1-DIS-012** | ✅ Implemented | Force disable idempotent (no VR on secondary) | ~4s                           | Full DR mode           |
 
 **Key Features:**
+
 - Removes replication from primary and secondary volumes
 - Primary volume becomes writeable after disable
 - Secondary volume remains read-only (not promoted)
@@ -227,18 +245,19 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## PromoteVolumeReplication API (5+ specs, 5+ test cases)
 
-| Spec | Status | Description | Duration | Requirements |
-|------|--------|-------------|----------|--------------|
-| **L1-PROM-001** | ✅ Implemented | Promote secondary → primary (healthy) | ~40s | Full DR mode |
-| **L1-PROM-002** | ✅ Implemented | Idempotent promote (already primary) | ~8s | Full DR mode |
-| **L1-PROM-007** | ✅ Implemented | Promote with active I/O workload | ~45s | Full DR mode |
-| **L1-PROM-008** | ✅ Implemented | Force promote with active I/O | ~45s | Full DR mode |
-| **L1-PROM-003** | ✅ Implemented | Promote with peer unreachable (force=false) | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
-| **L1-PROM-004** | ❌ Blocked | Promote with peer unreachable (force=true) | **Issue #7** | Full DR + NetworkFence |
-| **L1-PROM-005** | ❌ Blocked | Promote with array unreachable (force=false) | **Issue #9** | Full DR + iptables block |
-| **L1-PROM-006** | ❌ Blocked | Promote with array unreachable (force=true) | **Issue #9** | Full DR + iptables block |
+| Spec            | Status         | Description                                  | Duration                      | Requirements             |
+| --------------- | -------------- | -------------------------------------------- | ----------------------------- | ------------------------ |
+| **L1-PROM-001** | ✅ Implemented | Promote secondary → primary (healthy)        | ~40s                          | Full DR mode             |
+| **L1-PROM-002** | ✅ Implemented | Idempotent promote (already primary)         | ~8s                           | Full DR mode             |
+| **L1-PROM-007** | ✅ Implemented | Promote with active I/O workload             | ~45s                          | Full DR mode             |
+| **L1-PROM-008** | ✅ Implemented | Force promote with active I/O                | ~45s                          | Full DR mode             |
+| **L1-PROM-003** | ✅ Implemented | Promote with peer unreachable (force=false)  | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence   |
+| **L1-PROM-004** | ❌ Blocked     | Promote with peer unreachable (force=true)   | **Issue #7**                  | Full DR + NetworkFence   |
+| **L1-PROM-005** | ❌ Blocked     | Promote with array unreachable (force=false) | **Issue #9**                  | Full DR + iptables block |
+| **L1-PROM-006** | ❌ Blocked     | Promote with array unreachable (force=true)  | **Issue #9**                  | Full DR + iptables block |
 
 **Key Features:**
+
 - Transitions secondary VR to primary (Spec.ReplicationState: secondary→primary)
 - Monitors Status.State for PrimaryState transition
 - Promotes volume from RO (secondary) to RW (primary)
@@ -246,12 +265,14 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 - Tests graceful vs. force promotion modes
 
 **Blocked Tests:**
+
 - **L1-PROM-004:** [Issue #7 - RBD mirror force promote fails when degraded](https://github.com/nadavleva/kubernetes-csi-addons/issues/7)
+
   - **Problem**: VR state remains Secondary instead of transitioning to Primary when RBD mirror is degraded
   - **Status**: Awaiting RBD driver fix or workaround
-  
+
 - **L1-PROM-005, L1-PROM-006:** [Issue #9 - Array unreachability simulation via iptables](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-  - **Problem**: Test infrastructure cannot simulate local storage array becoming unreachable
+  - **Problem**: Test infrastructure cannot simulate on-node storage backend becoming unreachable
   - **Solution approach**: Block iptables rules on CSI client nodes to simulate storage array unavailability
   - **Status**: Awaiting infrastructure implementation (different from NetworkFence)
 
@@ -259,18 +280,19 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## DemoteVolumeReplication API (8+ specs, 8+ test cases)
 
-| Spec | Status | Description | Duration | Requirements |
-|------|--------|-------------|----------|--------------|
-| **L1-DEM-001** | ✅ Implemented | Demote primary → secondary (healthy) | ~225s | Full DR mode |
-| **L1-DEM-002** | ✅ Implemented | Idempotent demote (already secondary) | ~31s | Full DR mode |
-| **L1-DEM-007** | ✅ Implemented | Demote with active I/O workload | ~220s | Full DR mode |
-| **L1-DEM-008** | ✅ Implemented | Force demote with active I/O | ~220s | Full DR mode |
-| **L1-DEM-003** | ✅ Implemented | Demote with peer unreachable (force=false) | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence |
-| **L1-DEM-004** | ✅ Implemented | Demote with peer unreachable (force=true) | ~75s | Full DR + NetworkFence |
-| **L1-DEM-005** | ❌ Blocked | Demote with array unreachable (force=false) | **Issue #9** | Full DR + iptables block |
-| **L1-DEM-006** | ❌ Blocked | Demote with array unreachable (force=true) | **Issue #9** | Full DR + iptables block |
+| Spec           | Status         | Description                                 | Duration                      | Requirements             |
+| -------------- | -------------- | ------------------------------------------- | ----------------------------- | ------------------------ |
+| **L1-DEM-001** | ✅ Implemented | Demote primary → secondary (healthy)        | ~225s                         | Full DR mode             |
+| **L1-DEM-002** | ✅ Implemented | Idempotent demote (already secondary)       | ~31s                          | Full DR mode             |
+| **L1-DEM-007** | ✅ Implemented | Demote with active I/O workload             | ~220s                         | Full DR mode             |
+| **L1-DEM-008** | ✅ Implemented | Force demote with active I/O                | ~220s                         | Full DR mode             |
+| **L1-DEM-003** | ✅ Implemented | Demote with peer unreachable (force=false)  | ⏭️ Skipped if no NetworkFence | Full DR + NetworkFence   |
+| **L1-DEM-004** | ✅ Implemented | Demote with peer unreachable (force=true)   | ~75s                          | Full DR + NetworkFence   |
+| **L1-DEM-005** | ❌ Blocked     | Demote with array unreachable (force=false) | **Issue #9**                  | Full DR + iptables block |
+| **L1-DEM-006** | ❌ Blocked     | Demote with array unreachable (force=true)  | **Issue #9**                  | Full DR + iptables block |
 
 **Key Features:**
+
 - Transitions primary VR to secondary (Spec.ReplicationState: primary→secondary)
 - Monitors Status.State for SecondaryState transition
 - Demotes volume from RW (primary) to RO (secondary)
@@ -279,8 +301,9 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 - Includes RBD mirror resync on secondary (accounts for long duration)
 
 **Blocked Tests:**
+
 - **L1-DEM-005, L1-DEM-006:** [Issue #9 - Array unreachability simulation via iptables](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-  - **Problem**: Test infrastructure cannot simulate local storage array becoming unreachable
+  - **Problem**: Test infrastructure cannot simulate on-node storage backend becoming unreachable
   - **Solution approach**: Block iptables rules on CSI client nodes to simulate storage array unavailability
   - **Status**: Awaiting infrastructure implementation
 
@@ -288,13 +311,13 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## ResyncVolumeReplication API (5 specs, 5 test cases) - Scaffold
 
-| Spec | Status | Description | Duration | Requirements |
-|------|--------|-------------|----------|--------------|
-| **L1-RSYNC-001** | 🏗️ Scaffold | Resync secondary after split-brain | - | Full DR mode |
-| **L1-RSYNC-002** | 🏗️ Scaffold | Idempotent resync | - | Full DR mode |
-| **L1-RSYNC-003** | 🏗️ Scaffold | Resync with NetworkFence | - | Full DR + NetworkFence |
-| **L1-RSYNC-004** | 🏗️ Scaffold | Force resync | - | Full DR mode |
-| **L1-RSYNC-005** | 🏗️ Scaffold | Resync error handling | - | Full DR mode |
+| Spec             | Status      | Description                        | Duration | Requirements           |
+| ---------------- | ----------- | ---------------------------------- | -------- | ---------------------- |
+| **L1-RSYNC-001** | 🏗️ Scaffold | Resync secondary after split-brain | -        | Full DR mode           |
+| **L1-RSYNC-002** | 🏗️ Scaffold | Idempotent resync                  | -        | Full DR mode           |
+| **L1-RSYNC-003** | 🏗️ Scaffold | Resync with NetworkFence           | -        | Full DR + NetworkFence |
+| **L1-RSYNC-004** | 🏗️ Scaffold | Force resync                       | -        | Full DR mode           |
+| **L1-RSYNC-005** | 🏗️ Scaffold | Resync error handling              | -        | Full DR mode           |
 
 **Status**: Scaffolded but not yet implemented (tests exist but may be incomplete or skipped)
 
@@ -302,11 +325,12 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ## Full DR (Two-Cluster) Test (1 spec, 1 test case)
 
-| Spec | Status | Description | Duration | Requirements |
-|------|--------|-------------|----------|--------------|
-| **Full DR** | ✅ Implemented | Creates dual-cluster resources | ~6s | Full DR mode (DR1_CONTEXT + DR2_CONTEXT) |
+| Spec        | Status         | Description                    | Duration | Requirements                             |
+| ----------- | -------------- | ------------------------------ | -------- | ---------------------------------------- |
+| **Full DR** | ✅ Implemented | Creates dual-cluster resources | ~6s      | Full DR mode (DR1_CONTEXT + DR2_CONTEXT) |
 
 **Key Features:**
+
 - Validates that test infrastructure supports two-cluster mode
 - Creates namespace on both DR1 and DR2
 - Creates PVC and VR on DR1 only (primary)
@@ -316,12 +340,13 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ### Blocking Issues Summary
 
-| Issue | Specs Blocked | Problem | Solution | Status |
-|-------|--------|---------|----------|--------|
-| [#7](https://github.com/nadavleva/kubernetes-csi-addons/issues/7) | L1-PROM-004 (1) | CSI behavior: RBD mirror force promote fails when degraded with peer unreachable | Investigate RBD driver behavior; may require CSI driver enhancement or RBD config change | 🔍 Investigating |
-| [#9](https://github.com/nadavleva/kubernetes-csi-addons/issues/9) | L1-PROM-005, L1-PROM-006, L1-DEM-005, L1-DEM-006 (4) | Test infrastructure: Cannot simulate local storage array becoming unreachable | Add iptables blocking on CSI client nodes to simulate storage backend unavailability | In progress (created March 10, 2026) |
+| Issue                                                             | Specs Blocked                                        | Problem                                                                           | Solution                                                                                 | Status                               |
+| ----------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------ |
+| [#7](https://github.com/nadavleva/kubernetes-csi-addons/issues/7) | L1-PROM-004 (1)                                      | CSI behavior: RBD mirror force promote fails when degraded with peer unreachable  | Investigate RBD driver behavior; may require CSI driver enhancement or RBD config change | 🔍 Investigating                     |
+| [#9](https://github.com/nadavleva/kubernetes-csi-addons/issues/9) | L1-PROM-005, L1-PROM-006, L1-DEM-005, L1-DEM-006 (4) | Test infrastructure: Cannot simulate on-node storage backend becoming unreachable | Add iptables blocking on CSI client nodes to simulate storage backend unavailability     | In progress (created March 10, 2026) |
 
 **Skipped Test Breakdown:**
+
 - **1 test** blocked by CSI behavior investigation (Issue #7): Requires understanding RBD mirror force promote in degraded mode
 - **4 tests** blocked by infrastructure gaps (Issue #9): Requires iptables fault injection mechanism
 
@@ -330,18 +355,21 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 ### Test Execution Requirements
 
 **Single-Cluster Mode** (default):
+
 - Runs only tests that don't require peer cluster coordination
 - Does NOT require `DR1_CONTEXT` or `DR2_CONTEXT`
 - Covers: L1-E-001, L1-E-002, L1-E-004, L1-E-005, L1-E-006, L1-E-007, L1-E-008, L1-E-009, L1-INFO-008, L1-DIS-001, L1-DIS-003, L1-DIS-009, L1-DIS-011
 - Skipped with log: L1-DIS-002, L1-DIS-004, L1-DIS-010, L1-DIS-012, L1-DEM-001, L1-DEM-002, L1-DEM-007, L1-DEM-008, L1-PROM-001, L1-PROM-002, L1-PROM-007, L1-PROM-008, Full DR
 
 **Full DR Mode** (when `DR1_CONTEXT` and `DR2_CONTEXT` both set):
+
 - Runs all two-cluster tests
 - Enables L1-E-003 (NetworkFence) tests
 - Covers all Promote, Demote, Disable on secondary, Full DR tests
 - ~38-40 specs pass with healthy infrastructure
 
 **Skipped Tests:**
+
 - Tests requiring NetworkFence skip gracefully if `IsNetworkFenceSupportAvailable()` returns false
 - Tests requiring iptables infrastructure skip until Issue #9 implementation
 - All skips include log messages explaining the reason
@@ -350,30 +378,32 @@ REPLICATION_SECRET_NAME=rook-csi-rbd-provisioner REPLICATION_SECRET_NAMESPACE=ro
 
 ### Quick Comparison Table
 
-| Aspect | NetworkFence (Peer Unreachable) | Storage Array Unreachable |
-|--------|----------------------------------|---------------------------|
-| **What's blocked** | Network between clusters | Local storage backend |
-| **Local storage access** | ✅ Available | ❌ Unavailable |
-| **CSI operations** | May succeed (don't need peer) | Fail (need local storage) |
-| **PromoteVolume RPC** | ✅ Can execute (local only) | ❌ Fails (storage I/O error) |
-| **DemoteVolume RPC** | ✅ Can execute (local only) | ❌ Fails (storage I/O error) |
-| **force=true effect** | May allow skip peer coordination | ❌ Cannot override storage failure |
-| **Mirror status** | Degraded (peer down) | Unknown/error (no backend) |
-| **Recovery** | Unfence CRD / restore network | Restore storage backend |
-| **Duration of test** | Minutes | Until storage recovered |
-| **Test status** | ✅ Implemented (L1-E-003, L1-DIS-005, L1-DIS-006, etc.) | ❌ Not implemented (Issue #9) |
+| Aspect                     | NetworkFence (Peer Unreachable)                         | Storage Array Unreachable          |
+| -------------------------- | ------------------------------------------------------- | ---------------------------------- |
+| **What's blocked**         | Network between clusters                                | On-node storage backend            |
+| **Backend storage access** | ✅ Available                                            | ❌ Unavailable                     |
+| **CSI operations**         | May succeed (don't need peer)                           | Fail (need node storage)           |
+| **PromoteVolume RPC**      | ✅ Can execute (local only)                             | ❌ Fails (storage I/O error)       |
+| **DemoteVolume RPC**       | ✅ Can execute (local only)                             | ❌ Fails (storage I/O error)       |
+| **force=true effect**      | May allow skip peer coordination                        | ❌ Cannot override storage failure |
+| **Mirror status**          | Degraded (peer down)                                    | Unknown/error (no backend)         |
+| **Recovery**               | Unfence CRD / restore network                           | Restore storage backend            |
+| **Duration of test**       | Minutes                                                 | Until storage recovered            |
+| **Test status**            | ✅ Implemented (L1-E-003, L1-DIS-005, L1-DIS-006, etc.) | ❌ Not implemented (Issue #9)      |
 
 ---
 
 ### Why Both Scenarios Matter
 
 **NetworkFence tests** validate the controller's ability to:
+
 - Detect peer unreachability
 - Proceed with local operations gracefully
 - Recover automatically when network restores
 - Prevent split-brain situations
 
 **Storage array unreachability tests** validate the controller's ability to:
+
 - Fail safely when storage backend is unreachable
 - Report appropriate error conditions in VR status
 - NOT attempt retries that cannot succeed
@@ -386,6 +416,7 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
 **As of March 5, 2026 (20:52:42):**
 
 ### Test Execution Results
+
 - **Total Specs**: 37 (37 executed, 5 skipped)
 - **Passed**: 38 ✅
 - **Skipped**: 5 (blocked on GitHub issues)
@@ -394,21 +425,22 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
 
 ### Test Execution Breakdown by Category
 
-| Category | Total | Passed | Skipped | Status |
-|----------|-------|--------|---------|--------|
-| EnableVolumeReplication (L1-E-001 to L1-E-009) | 9 | 9 | 0 | ✅ Complete |
-| DisableVolumeReplication (L1-DIS-001 to L1-DIS-012) | 12 | 12 | 0 | ✅ Complete |
-| GetVolumeReplicationInfo (integrated with Enable/Disable) | - | - | - | ✅ Complete |
-| PromoteVolumeReplication (L1-PROM-001,002,003,007,008) | 5 | 5 | 0 | ✅ Complete |
-| DemoteVolumeReplication (L1-DEM-001,002,003,004,007,008) | 6 | 6 | 0 | ✅ Complete |
-| ResyncVolumeReplication (L1-RSYNC-001 to L1-RSYNC-005) | 5 | 5 | 0 | ✅ Complete |
-| Full DR (two clusters) | 1 | 1 | 0 | ✅ Complete |
-| **Skipped Tests** | **5** | - | **5** | ⏭️ Blocked |
-| **TOTAL** | **42** | **38** | **5** | |
+| Category                                                  | Total  | Passed | Skipped | Status      |
+| --------------------------------------------------------- | ------ | ------ | ------- | ----------- |
+| EnableVolumeReplication (L1-E-001 to L1-E-009)            | 9      | 9      | 0       | ✅ Complete |
+| DisableVolumeReplication (L1-DIS-001 to L1-DIS-012)       | 12     | 12     | 0       | ✅ Complete |
+| GetVolumeReplicationInfo (integrated with Enable/Disable) | -      | -      | -       | ✅ Complete |
+| PromoteVolumeReplication (L1-PROM-001,002,003,007,008)    | 5      | 5      | 0       | ✅ Complete |
+| DemoteVolumeReplication (L1-DEM-001,002,003,004,007,008)  | 6      | 6      | 0       | ✅ Complete |
+| ResyncVolumeReplication (L1-RSYNC-001 to L1-RSYNC-005)    | 5      | 5      | 0       | ✅ Complete |
+| Full DR (two clusters)                                    | 1      | 1      | 0       | ✅ Complete |
+| **Skipped Tests**                                         | **5**  | -      | **5**   | ⏭️ Blocked  |
+| **TOTAL**                                                 | **42** | **38** | **5**   |             |
 
 ### Skipped Tests with Blocking Issues
 
 #### 1. L1-PROM-004: Promote secondary to primary with peer unreachable (force=true)
+
 - **Issue**: [#7 - Investigate: Force promote fails when RBD mirror is degraded with peer unreachable](https://github.com/nadavleva/kubernetes-csi-addons/issues/7)
 - **Root Cause**: RBD mirror force promote issue in degraded mode
 - **Current Behavior**: VR state remains Secondary instead of transitioning to Primary
@@ -419,39 +451,44 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
   - May require RBD configuration or driver-level changes
 
 #### 2. L1-PROM-005: Promote secondary to primary with array unreachable (force=false)
-- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in E2E Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-- **Root Cause**: Test infrastructure cannot simulate local storage array unavailability
+
+- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in end-to-end Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
+- **Root Cause**: Test infrastructure cannot simulate on-node storage array unavailability
 - **Gap**: Current infrastructure only supports NetworkFence (blocks peer cluster network access)
-- **What's Missing**: Mechanism to make local storage backend unavailable (e.g., Ceph pool offline)
+- **What's Missing**: Mechanism to make the storage backend unavailable (e.g., Ceph pool offline)
 - **Expected Test Behavior**: CSI driver should report storage unavailable; PromoteVolume RPC fails; VR shows Degraded=True with FailedToPromote reason
 
 #### 3. L1-PROM-006: Promote secondary to primary with array unreachable (force=true)
-- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in E2E Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-- **Root Cause**: Test infrastructure cannot simulate local storage array unavailability
-- **Expected Test Behavior**: force=true should NOT override storage layer failures; operation still fails because local storage is unreachable
+
+- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in end-to-end Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
+- **Root Cause**: Test infrastructure cannot simulate on-node storage array unavailability
+- **Expected Test Behavior**: force=true should NOT override storage layer failures; operation still fails because the storage backend is unreachable
 - **Key Validation**: force parameter affects peer coordination only, not storage layer access
 
 #### 4. L1-DEM-005: Demote primary to secondary with array unreachable (force=false)
-- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in E2E Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-- **Root Cause**: Test infrastructure cannot simulate local storage array unavailability
+
+- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in end-to-end Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
+- **Root Cause**: Test infrastructure cannot simulate on-node storage array unavailability
 - **Expected Test Behavior**: DemoteVolume RPC requires primary storage access; when storage is unreachable, operation fails with Degraded=True, FailedToDemote reason
 
 #### 5. L1-DEM-006: Demote primary to secondary with array unreachable (force=true)
-- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in E2E Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
-- **Root Cause**: Test infrastructure cannot simulate local storage array unavailability
+
+- **Issue**: [#9 - Test Infrastructure Gap: Support for Array/Storage Unreachability Simulation in end-to-end Tests](https://github.com/nadavleva/kubernetes-csi-addons/issues/9)
+- **Root Cause**: Test infrastructure cannot simulate on-node storage array unavailability
 - **Expected Test Behavior**: force=true still fails when primary storage is unavailable; force parameter cannot override storage layer access requirements
 
 ### Issue Summary
 
-| Issue | Title | Blocking Tests | Priority | Status | Last Updated |
-|-------|-------|---|----------|--------|--------------|
-| #7 | RBD mirror force promote degraded with peer unreachable | L1-PROM-004 (1 test) | **High** | 🔍 Investigating | March 10, 2026 |
-| #9 | Array/Storage unreachability test infrastructure gap (iptables fault injection on CSI client nodes) | L1-PROM-005, L1-PROM-006, L1-DEM-005, L1-DEM-006 (4 tests) | **Medium** | 📋 Pending Implementation | March 10, 2026 |
-| #10 | Dangling RBD images after failed promote/demote operations | Related to L1-PROM-001, L1-DEM-001, L1-PROM-005/6, L1-DEM-005/6 | **Medium** | 📋 Pending Investigation | March 10, 2026 |
+| Issue | Title                                                                                               | Blocking Tests                                                  | Priority   | Status                    | Last Updated   |
+| ----- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------- | ------------------------- | -------------- |
+| #7    | RBD mirror force promote degraded with peer unreachable                                             | L1-PROM-004 (1 test)                                            | **High**   | 🔍 Investigating          | March 10, 2026 |
+| #9    | Array/Storage unreachability test infrastructure gap (iptables fault injection on CSI client nodes) | L1-PROM-005, L1-PROM-006, L1-DEM-005, L1-DEM-006 (4 tests)      | **Medium** | 📋 Pending Implementation | March 10, 2026 |
+| #10   | Dangling RBD images after failed promote/demote operations                                          | Related to L1-PROM-001, L1-DEM-001, L1-PROM-005/6, L1-DEM-005/6 | **Medium** | 📋 Pending Investigation  | March 10, 2026 |
 
 ### Issue Details
 
 #### Issue #7: RBD Mirror Force Promote Degraded with Peer Unreachable
+
 - **Description**: When RBD mirror is degraded (peer unreachable) and force promote is attempted on secondary, VR state remains Secondary instead of transitioning to Primary
 - **Affected Test**: L1-PROM-004
 - **Root Cause**: RBD mirror daemon behavior in degraded mode may not support forced promotion
@@ -461,7 +498,8 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
   - May require driver-level changes or updates to Ceph CSI
 
 #### Issue #9: Array/Storage Unreachability Test Infrastructure Gap
-- **Description**: Test infrastructure cannot simulate local storage array becoming unreachable. Current infrastructure only supports NetworkFence (blocks peer cluster network).
+
+- **Description**: Test infrastructure cannot simulate on-node storage backend becoming unreachable. Current infrastructure only supports NetworkFence (blocks peer cluster network).
 - **Affected Tests**: L1-PROM-005, L1-PROM-006, L1-DEM-005, L1-DEM-006
 - **Implementation Approach**: Use iptables blocking rules on CSI client nodes to simulate storage backend unavailability
 - **Expected Behavior**: CSI driver should report storage unavailable errors; operations fail with appropriate error codes
@@ -472,6 +510,7 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
   4. Clean up iptables rules after test completion
 
 #### Issue #10: Dangling RBD Images After Failed Operations
+
 - **Description**: When promote/demote operations fail or are interrupted, orphaned RBD mirror images may remain on the storage backend
 - **Affected Tests**: All promote/demote tests, especially those with storage unreachability (#9)
 - **Problem Areas**:
@@ -486,6 +525,7 @@ Together, they ensure comprehensive failure scenario coverage for disaster recov
   4. Add validation to ensure no dangling images after each test
 
 ### Not Yet Implemented (Noted in matrix)
+
 - L1-PROM-003, L1-DEM-003, L1-DEM-004: Peer/array down scenarios (future enhancement, related to #7 and #9)
 - L1-INFO-008 (standalone): Non-existent volume error handling (not integrated with Enable tests yet)
 
@@ -500,6 +540,7 @@ RBD images created during VolumeReplication test operations can become "dangling
 ### Lifecycle: How Dangling Images Are Created
 
 **Normal Healthy Operations:**
+
 1. Test creates PVC on primary cluster
 2. VolumeReplication enables mirroring on primary
 3. RBD mirror daemon creates mirror image on secondary Ceph cluster
@@ -508,16 +549,18 @@ RBD images created during VolumeReplication test operations can become "dangling
 6. Test cleanup deletes PVCs, which triggers RBD image deletion
 
 **Failure Scenario 1: Secondary PVC Creation Fails**
-```
+
+```plaintext
 [Primary Cluster]                    [Secondary Cluster]
 PVC created ✅          →  RBD mirror image created ✅
                         →  Secondary PVC creation ❌ (fails mid-operation)
-                        
+
 Result: Orphaned RBD mirror image remains on secondary
 ```
 
 **Failure Scenario 2: Cleanup Incomplete**
-```
+
+```plaintext
 VR/PVC deletion requested ✅
 PVC finalizers removed ✅
 PVC deleted from K8s ✅
@@ -527,14 +570,15 @@ Result: RBD image persists on storage backend
 ```
 
 **Failure Scenario 3: Test Interrupted (Timeout, Panic, Kill)**
-```
+
+```plaintext
 Test running...
     ├─ Created resources on both clusters
     ├─ Enabled replication
     ├─ Created secondary PVC from mirror
     │
     └─ INTERRUPTED (timeout, panic, or ^C)
-    
+
 Cleanup handler runs but may not complete fully
 Result: Partial cleanup, dangling images remain
 ```
@@ -542,14 +586,16 @@ Result: Partial cleanup, dangling images remain
 ### Storage Impact
 
 **Per-test resource overhead:**
+
 - Primary volume: 1-2 GiB (test volume)
 - Secondary mirror: 1-2 GiB (mirrored copy)
 - RBD snapshots (if any): 0-1 GiB
 
 **For failed tests with dangling images:**
+
 - Orphaned mirror image: 1-2 GiB per orphaned volume
 - Failed test run (42 tests): Up to 84+ GiB of dangling images if all fail
-- E2E test suite runs (daily): Hundreds of GiB accumulation risk
+- end-to-end test suite runs (daily): Hundreds of GiB accumulation risk
 
 ### Identifying Dangling Images
 
@@ -568,8 +614,9 @@ kubectl get pvc -A -o jsonpath='{.items[*].spec.volumeName}' | xargs -I {} \
 ```
 
 **For test-specific images:**
+
 ```bash
-# E2E test images follow naming pattern: pvc-<random-suffix> or vr-<random-suffix>
+# end-to-end test images follow naming pattern: pvc-<random-suffix> or vr-<random-suffix>
 rbd ls --pool <pool-name> | grep -E 'pvc-|vr-'
 
 # Check for images older than test run duration (e.g., 1 hour old)
@@ -578,13 +625,15 @@ rbd info --pool <pool-name> <image> | grep 'create_timestamp'
 
 ### Current Cleanup Strategy (Limitations)
 
-**Current cleanup (in `clean-replication-e2e-resources.sh`):**
+**Current cleanup (in `clean-replication-end-to-end-resources.sh`):**
+
 1. Deletes K8s PVCs (triggers RBD deletion)
 2. Waits for RBD deletion via K8s event watching
 3. Removes VR/VRC finalizers if stuck
 4. **Does NOT directly query Ceph for orphaned images**
 
 **Limitations:**
+
 - Relies on K8s-initiated RBD deletion (fails if communication broken)
 - No fallback to direct Ceph cleanup
 - No validation that RBD images were actually deleted
@@ -595,25 +644,29 @@ rbd info --pool <pool-name> <image> | grep 'create_timestamp'
 **Enhanced cleanup should:**
 
 1. **Pre-cleanup audit:**
+
    ```bash
    # Record RBD images before test
    rbd ls --pool <pool> > images_before.txt
    ```
 
 2. **Standard K8s cleanup:**
+
    - Delete resources as normal (current approach)
    - Wait for finalizers to complete
 
 3. **Post-cleanup validation:**
+
    ```bash
    # Record RBD images after test cleanup
    rbd ls --pool <pool> > images_after.txt
-   
+
    # Identify dangling images (present after, but created during test)
    comm -13 images_before.txt images_after.txt > dangling_images.txt
    ```
 
 4. **Force cleanup of dangling images:**
+
    ```bash
    # Remove dangling mirror images
    for image in $(cat dangling_images.txt); do
@@ -629,14 +682,14 @@ rbd info --pool <pool-name> <image> | grep 'create_timestamp'
 
 ### Test Cleanup Enhancements Required
 
-**Updates needed to `clean-replication-e2e-resources.sh`:**
+**Updates needed to `clean-replication-end-to-end-resources.sh`:**
 
 ```bash
 #!/bin/bash
 # Enhanced cleanup with dangling image detection
 
 POOL="${CEPH_POOL:-rbd}"
-NAMESPACE_PREFIX="e2e-replication-"
+NAMESPACE_PREFIX="end-to-end-replication-"
 
 # 1. Record RBD images before cleanup
 echo "[PRE] Listing RBD images before cleanup..."
@@ -662,7 +715,7 @@ if [ -z "$DANGLING" ]; then
 else
   echo "⚠️  WARNING: Found dangling images:"
   echo "$DANGLING"
-  
+
   # 5. Force cleanup dangling images
   echo "[CLEANUP] Removing dangling RBD images..."
   for image in $DANGLING; do
@@ -670,13 +723,13 @@ else
     rbd mirror image disable --force --pool $POOL $image 2>/dev/null || true
     rbd rm --pool $POOL $image || echo "  ❌ Failed to remove $image"
   done
-  
+
   # 6. Validate cleanup
   echo "[VALIDATE] Checking if dangling images were removed..."
   rbd ls --pool $POOL > /tmp/images_final.txt
   REMAINING=$(comm -23 /tmp/images_final.txt /tmp/images_pre_cleanup.txt | \
               grep -E 'pvc-|vr-' || true)
-  
+
   if [ -z "$REMAINING" ]; then
     echo "✅ All dangling images cleaned up"
   else
@@ -692,23 +745,25 @@ fi
 **To minimize dangling image accumulation:**
 
 1. **Use unique naming per test run:**
+
    ```bash
    # Each test run gets a unique suffix
    RUN_ID=$(date +%s)_$(openssl rand -hex 4)
-   
+
    # PVCs, VRs use RUN_ID: pvc-$RUN_ID-001, vr-$RUN_ID-001
    ```
 
 2. **Enable strict cleanup validation:**
+
    ```bash
    # After each test, validate no orphaned images were created
    test_cleanup() {
      local namespace=$1
      local run_id=$2
-     
+
      # Delete K8s resources
      kubectl delete namespace $namespace
-     
+
      # Check for orphaned images with this run_id
      local orphaned=$(rbd ls --pool $POOL | grep $run_id || true)
      if [ -n "$orphaned" ]; then
@@ -736,15 +791,18 @@ fi
 **Recommended monitoring additions:**
 
 1. **Pre-test Ceph audit:**
+
    - Record baseline orphaned image count
    - Fail suite if orphaned count exceeds threshold (e.g., 10)
 
 2. **Per-test resource tracking:**
+
    - Log PVC/VR creation and deletion timestamps
    - Compare against RBD image creation/deletion events
 
 3. **Post-suite report:**
-   ```
+
+```plaintext
    ========================================
    TEST SUITE CLEANUP REPORT
    ========================================
@@ -752,43 +810,46 @@ fi
    RBD Images Deleted:        116
    Dangling Images:           4
    Orphaned Storage:          8 GiB
-   
+
    Dangling images:
    - pvc-abc123-001 (224 MiB, 2h old)
    - mirror-xyz789-001 (1.5 GiB, 1h old)
    ...
    ========================================
-   ```
+```
 
 ## NetworkFence capability detection
 
 **Optimization (as of this version):** NetworkFence capability detection is performed **once** at BeforeSuite initialization (after client creation) and cached for all tests. Previously, L1-E-003 called `HasNetworkFenceSupport()` on every run, which checked CRDs and CSIAddonsNode capabilities every time.
 
 **How it works:**
+
 1. At BeforeSuite, `HasNetworkFenceSupport()` is called with the detected provisioner name
 2. Result (bool) is cached in module-level variable `networkFenceSupportCached`
 3. Tests call `IsNetworkFenceSupportAvailable()` (defined in suite_test.go) to retrieve the cached result
 4. L1-E-003 and future NetworkFence-dependent tests skip gracefully if not available
 
 **Benefits:**
+
 - Single capability check per test run vs. per-test overhead
 - Cluster query reduced from O(n_tests) to O(1)
 - Cleaner test code: tests don't pass `ctx`, `client`, `provisioner` to capability check
 
 **Limitations:**
+
 - Cached result assumes provisioner does not change during test run (reasonable assumption for single-provisioner suites)
 - Multi-provisioner suites can call `HasNetworkFenceSupport()` directly for each provisioner if needed
 
 ## Cleanup and finalizers
 
-The controller adds finalizers to VolumeReplication (`replication.storage.openshift.io`) and to PVCs (`replication.storage.openshift.io/pvc-protection`). On delete, the controller removes them after disabling replication. The e2e suite cleanup:
+The controller adds finalizers to VolumeReplication (`replication.storage.openshift.io`) and to PVCs (`replication.storage.openshift.io/pvc-protection`). On delete, the controller removes them after disabling replication. The end-to-end suite cleanup:
 
 1. Deletes VR first, then VRC, then PVC, then namespace.
 2. Waits up to 45 seconds for each resource to be gone after delete.
 3. If a VR or PVC is still present (e.g. controller cannot reach the driver), the test removes the replication finalizer so the resource can be deleted and the namespace can terminate.
 4. **Multi-cluster cleanup:** When DR1_CONTEXT and DR2_CONTEXT are set, cleanup script removes finalizers and deletes resources from **all clusters** (loops through both contexts). Orphaned resources on secondary cluster are properly cleaned up even if primary cleanup fails.
 
-So leftover Terminating PVCs or VRs from failed runs should be cleared by the next run's cleanup, or you can remove the finalizers manually if needed. The cleanup script (`clean-replication-e2e-resources.sh`) has been updated to support multi-cluster contexts, ensuring no orphaned resources remain on either cluster.
+So leftover Terminating PVCs or VRs from failed runs should be cleared by the next run's cleanup, or you can remove the finalizers manually if needed. The cleanup script (`clean-replication-end-to-end-resources.sh`) has been updated to support multi-cluster contexts, ensuring no orphaned resources remain on either cluster.
 
 ## VolumeReplication status.State = Unknown
 
@@ -801,13 +862,15 @@ If either call fails (e.g. sidecar unreachable, driver error, or no CSIAddonsNod
 
 **What to check when State stays Unknown:**
 
-- **Controller and VRs in the same cluster**  
+- **Controller and VRs in the same cluster**
   The CSI-Addons controller only reconciles VRs in the cluster where it runs. If VRs are created in cluster A but the controller runs in cluster B, those VRs are never reconciled and State is never set.
-- **VRC provisioner must match CSIAddonsNode driver name**  
-  The controller looks up a CSIAddonsNode whose `spec.driver.name` **exactly** matches the VolumeReplicationClass `spec.provisioner`. If they differ (e.g. VRC uses `rook-ceph.rbd.csi.ceph.com` but CSIAddonsNode uses `rbd.csi.ceph.com`), the controller never finds a connection and State stays Unknown. The e2e tests default the VRC provisioner to `rook-ceph.rbd.csi.ceph.com`; set env **`CSI_PROVISIONER`** to match your CSIAddonsNode driver name when running the suite (and when creating VRCs manually).
-- **CSIAddonsNode exists and supports VolumeReplication**  
+- **VRC provisioner must match CSIAddonsNode driver name**
+  The controller looks up a CSIAddonsNode whose `spec.driver.name` **exactly** matches the VolumeReplicationClass `spec.provisioner`.
+  If they differ (e.g. VRC uses `rook-ceph.rbd.csi.ceph.com` but CSIAddonsNode uses `rbd.csi.ceph.com`), the controller never finds a connection and State stays Unknown.
+  The end-to-end tests default the VRC provisioner to `rook-ceph.rbd.csi.ceph.com`; set env **`CSI_PROVISIONER`** to match your CSIAddonsNode driver name when running the suite (and when creating VRCs manually).
+- **CSIAddonsNode exists and supports VolumeReplication**
   If there is no CSIAddonsNode for the provisioner, or it does not advertise VolumeReplication, the controller cannot call the driver.
-- **Controller logs**  
+- **Controller logs**
   Look for errors like “failed to enable replication”, “failed to promote volume”, or “leading CSIAddonsNode … for driver … does not support VolumeReplication” in the controller pod logs.
 
 **Diagnostic script:** To quickly see provisioner vs driver names and controller errors, run:
@@ -817,17 +880,19 @@ If either call fails (e.g. sidecar unreachable, driver error, or no CSIAddonsNod
 # Or for a specific VR: ./hack/diagnose-replication-vr.sh <namespace> <vr-name>
 ```
 
-Example: `./hack/diagnose-replication-vr.sh e2e-replication-b8c5f92a vr-snapshot`
+Example: `./hack/diagnose-replication-vr.sh end-to-end-replication-b8c5f92a vr-snapshot`
 
 The tests accept either `Primary` or `Unknown` when the Replicating condition is True.
 
-**Error conditions:** The controller signals failure by setting **ConditionDegraded** with **Status=True** (and Reason=Error, etc.), and **ConditionCompleted** with Status=False and a failure Reason (FailedToPromote, FailedToDemote, FailedToResync). It does not use ConditionFalse alone to mean "error". The e2e helpers (`hasVolumeReplicationErrorCondition`, `WaitForVolumeReplicationError`) are written to match this so that: (1) tests that expect an error (e.g. L1-INFO-008) detect it, and (2) L1-E-005’s "assert no error" on the idempotent second VR does not false-positive when the controller leaves the duplicate VR’s status untouched.
+**Error conditions:** The controller signals failure by setting **ConditionDegraded** with **Status=True** (and Reason=Error, etc.), and **ConditionCompleted** with Status=False and a failure Reason (FailedToPromote, FailedToDemote, FailedToResync).
+It does not use ConditionFalse alone to mean "error".
+The end-to-end helpers (`hasVolumeReplicationErrorCondition`, `WaitForVolumeReplicationError`) are written to match this so that: (1) tests that expect an error (e.g. L1-INFO-008) detect it, and (2) L1-E-005’s "assert no error" on the idempotent second VR does not false-positive when the controller leaves the duplicate VR’s status untouched.
 
 ## Single cluster vs full DR (two clusters)
 
 **Single cluster (default):** Omit `DR1_CONTEXT` and `DR2_CONTEXT`; the suite uses the current kubeconfig context. Use `kubectl config use-context <name>` then `make test-replication-e2e` to target a cluster.
 
-The e2e suite creates all resources (namespaces, PVCs, VolumeReplications, VolumeReplicationClasses) in **the cluster that your kubeconfig is currently using**. It does not have a built-in notion of “DR1” vs “DR2”; it simply uses the default context (or the one set by `KUBECONFIG`).
+The end-to-end suite creates all resources (namespaces, PVCs, VolumeReplications, VolumeReplicationClasses) in **the cluster that your kubeconfig is currently using**. It does not have a built-in notion of “DR1” vs “DR2”; it simply uses the default context (or the one set by `KUBECONFIG`).
 
 **Full DR mode (two clusters):** Set both `DR1_CONTEXT` and `DR2_CONTEXT` to context names in your kubeconfig. The suite builds two clients, uses DR1 as primary, and runs "Full DR (two clusters)" tests. Example:
 
@@ -850,6 +915,7 @@ These tests require `USE_EXISTING_CLUSTER=true`. Do not run them with `make test
 The full test plan below enumerates all endpoint, state, and workflow-driven scenarios for Layer-1 CSI Replication driver conformance. It is intended for use by certification tools, automation, and test writers.
 
 **Columns:**
+
 - Test ID
 - API (gRPC/CRD)
 - Scenario/Description
@@ -862,109 +928,110 @@ The full test plan below enumerates all endpoint, state, and workflow-driven sce
 
 ### EnableVolumeReplication
 
-| Test ID   | API                    | Scenario                              | Role       | Peer State | Params          | Test Type   | Setup/Input                                    | Expected Outcome                                            | Notes/Link             |
-|-----------|------------------------|---------------------------------------|------------|------------|-----------------|-------------|-----------------------------------------------|-------------------------------------------------------------|------------------------|
-| L1-E-001  | EnableVolumeReplication| Enable snapshot mode                  | Primary    | Up         | mode=snapshot   | functional  | Volume present, PVC bound, rep. disabled      | VR CR created, status.replicationHandle populated           |                        |
-| L1-E-002  | EnableVolumeReplication| Enable journal mode                   | Primary    | Up         | mode=journal    | functional  | Volume present, PVC bound, rep. disabled      | VR CR created, continuous replication active                 |                        |
-| L1-E-003  | EnableVolumeReplication| Peer cluster unreachable              | Primary    | Down       | mode=snapshot   | negative    | Peer/all unreachable network                   | Operation fails: timeout, appropriate error in status        | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-E-004  | EnableVolumeReplication| Invalid interval parameter            | Primary    | Up         | interval=5x     | negative    | Bad parameter                                 | Returns gRPC InvalidArgument error                           |                        |
-| L1-E-005  | EnableVolumeReplication| Already enabled volume                | Primary    | Up         | (none)          | functional  | VR CR exists, rep enabled already             | Idempotent, operation succeeds with no change                |                        |
-| L1-E-006  | EnableVolumeReplication| Secret reference missing/invalid      | Primary    | Up         | secret=missing  | negative    | Bad rep. secret ref                            | gRPC FailedPrecondition error                                |                        |
-| L1-E-007  | EnableVolumeReplication| Invalid mirroringMode parameter       | Primary    | Up         | mode=invalid    | negative    | Bad mirroringMode parameter                    | Returns gRPC InvalidArgument error                           |                        |
-| L1-E-008  | EnableVolumeReplication| Future schedulingStartTime            | Primary    | Up         | mode=snapshot, startTime=+30s | functional | Valid future start time                        | VR CR created, scheduling starts at specified time          |                        |
-| L1-E-009  | EnableVolumeReplication| Invalid schedulingStartTime format    | Primary    | Up         | mode=snapshot, startTime=invalid | negative | Bad time format parameter                      | Returns gRPC InvalidArgument error                           |                        |
+| Test ID  | API                     | Scenario                           | Role    | Peer State | Params                           | Test Type  | Setup/Input                              | Expected Outcome                                      | Notes/Link                                                                                                      |
+| -------- | ----------------------- | ---------------------------------- | ------- | ---------- | -------------------------------- | ---------- | ---------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| L1-E-001 | EnableVolumeReplication | Enable snapshot mode               | Primary | Up         | mode=snapshot                    | functional | Volume present, PVC bound, rep. disabled | VR CR created, status.replicationHandle populated     |                                                                                                                 |
+| L1-E-002 | EnableVolumeReplication | Enable journal mode                | Primary | Up         | mode=journal                     | functional | Volume present, PVC bound, rep. disabled | VR CR created, continuous replication active          |                                                                                                                 |
+| L1-E-003 | EnableVolumeReplication | Peer cluster unreachable           | Primary | Down       | mode=snapshot                    | negative   | Peer/all unreachable network             | Operation fails: timeout, appropriate error in status | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-E-004 | EnableVolumeReplication | Invalid interval parameter         | Primary | Up         | interval=5x                      | negative   | Bad parameter                            | Returns gRPC InvalidArgument error                    |                                                                                                                 |
+| L1-E-005 | EnableVolumeReplication | Already enabled volume             | Primary | Up         | (none)                           | functional | VR CR exists, rep enabled already        | Idempotent, operation succeeds with no change         |                                                                                                                 |
+| L1-E-006 | EnableVolumeReplication | Secret reference missing/invalid   | Primary | Up         | secret=missing                   | negative   | Bad rep. secret ref                      | gRPC FailedPrecondition error                         |                                                                                                                 |
+| L1-E-007 | EnableVolumeReplication | Invalid mirroringMode parameter    | Primary | Up         | mode=invalid                     | negative   | Bad mirroringMode parameter              | Returns gRPC InvalidArgument error                    |                                                                                                                 |
+| L1-E-008 | EnableVolumeReplication | Future schedulingStartTime         | Primary | Up         | mode=snapshot, startTime=+30s    | functional | Valid future start time                  | VR CR created, scheduling starts at specified time    |                                                                                                                 |
+| L1-E-009 | EnableVolumeReplication | Invalid schedulingStartTime format | Primary | Up         | mode=snapshot, startTime=invalid | negative   | Bad time format parameter                | Returns gRPC InvalidArgument error                    |                                                                                                                 |
 
 **EnableVolumeReplication Test Count: 9 scenarios**
 
 ### DisableVolumeReplication (all key permutations)
 
-| Test ID   | API                        | Scenario                             | Node Role  | Peer State | Array State | Params       | Test Type   | Setup/Input                                 | Expected Outcome                                     | Notes/Link             |
-|-----------|----------------------------|--------------------------------------|------------|------------|-------------|--------------|-------------|----------------------------------------------|------------------------------------------------------|------------------------|
-| L1-DIS-001| DisableVolumeReplication   | Disable, active, peer up             | Primary    | Up         | Up          | force=false  | functional  | Rep enabled, all healthy                    | Replication removed, volume writeable                |                        |
-| L1-DIS-002| DisableVolumeReplication   | Disable, active, peer up             | Secondary  | Up         | Up          | force=false  | functional  | Rep enabled, all healthy                    | Replication stopped; secondary remains RO            |                        |
-| L1-DIS-003| DisableVolumeReplication   | Previously disabled, peer up         | Primary    | Up         | Up          | force=false  | functional  | No replication relationship                 | Idempotent, no error                                |                        |
-| L1-DIS-004| DisableVolumeReplication   | Previously disabled, peer up         | Secondary  | Up         | Up          | force=false  | functional  | No replication relationship                 | Idempotent, no error                                |                        |
-| L1-DIS-005| DisableVolumeReplication   | Peer down, force=false               | Primary    | Down       | Up          | force=false  | negative    | Peer unreachable (simulate network failure) | Fails gracefully, logs/unavailable                   | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DIS-006| DisableVolumeReplication   | Peer down, force=true                | Primary    | Down       | Up          | force=true   | behavioral  | Peer unreachable, force=true                | Immediate disable, makes primary writeable (warn)    |                        |
-| L1-DIS-007| DisableVolumeReplication   | Array unreachable, force=false       | Primary    | Up         | Down        | force=false  | negative    | Disconnect primary array                     | Fails, error code: array unreachable                 | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DIS-008| DisableVolumeReplication   | Array unreachable, force=true        | Secondary  | Up         | Down        | force=true   | negative    | Disconnect secondary array                   | Fails, error code: array unreachable                 | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| Test ID    | API                      | Scenario                       | Node Role | Peer State | Array State | Params      | Test Type  | Setup/Input                                 | Expected Outcome                                  | Notes/Link                                                                                                      |
+| ---------- | ------------------------ | ------------------------------ | --------- | ---------- | ----------- | ----------- | ---------- | ------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| L1-DIS-001 | DisableVolumeReplication | Disable, active, peer up       | Primary   | Up         | Up          | force=false | functional | Rep enabled, all healthy                    | Replication removed, volume writeable             |                                                                                                                 |
+| L1-DIS-002 | DisableVolumeReplication | Disable, active, peer up       | Secondary | Up         | Up          | force=false | functional | Rep enabled, all healthy                    | Replication stopped; secondary remains RO         |                                                                                                                 |
+| L1-DIS-003 | DisableVolumeReplication | Previously disabled, peer up   | Primary   | Up         | Up          | force=false | functional | No replication relationship                 | Idempotent, no error                              |                                                                                                                 |
+| L1-DIS-004 | DisableVolumeReplication | Previously disabled, peer up   | Secondary | Up         | Up          | force=false | functional | No replication relationship                 | Idempotent, no error                              |                                                                                                                 |
+| L1-DIS-005 | DisableVolumeReplication | Peer down, force=false         | Primary   | Down       | Up          | force=false | negative   | Peer unreachable (simulate network failure) | Fails gracefully, logs/unavailable                | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DIS-006 | DisableVolumeReplication | Peer down, force=true          | Primary   | Down       | Up          | force=true  | behavioral | Peer unreachable, force=true                | Immediate disable, makes primary writeable (warn) |                                                                                                                 |
+| L1-DIS-007 | DisableVolumeReplication | Array unreachable, force=false | Primary   | Up         | Down        | force=false | negative   | Disconnect primary array                    | Fails, error code: array unreachable              | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DIS-008 | DisableVolumeReplication | Array unreachable, force=true  | Secondary | Up         | Down        | force=true  | negative   | Disconnect secondary array                  | Fails, error code: array unreachable              | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
 
 #### DisableVolumeReplication with force=true (Complete Test Matrix)
 
-| Test ID   | API                        | Scenario                                 | Node Role  | Peer State | Array State | Params       | Test Type   | Setup/Input                                 | Expected Outcome                                     | Notes/Link             |
-|-----------|----------------------------|------------------------------------------|------------|------------|-------------|--------------|-------------|----------------------------------------------|------------------------------------------------------|------------------------|
-| L1-DIS-009| DisableVolumeReplication   | Force disable, active, peer up           | Primary    | Up         | Up          | force=true   | behavioral  | Rep enabled, all healthy, force=true        | Immediate disable, volume writeable, warn logged     |                        |
-| L1-DIS-010| DisableVolumeReplication   | Force disable, active, peer up           | Secondary  | Up         | Up          | force=true   | behavioral  | Rep enabled, all healthy, force=true        | Immediate disable, secondary disconnected, warn logged|                        |
-| L1-DIS-011| DisableVolumeReplication   | Force disable, previously disabled       | Primary    | Up         | Up          | force=true   | functional  | No replication relationship, force=true     | Idempotent, no error                                |                        |
-| L1-DIS-012| DisableVolumeReplication   | Force disable, previously disabled       | Secondary  | Up         | Up          | force=true   | functional  | No replication relationship, force=true     | Idempotent, no error                                |                        |
-| L1-DIS-013| DisableVolumeReplication   | Force disable, peer down                  | Primary    | Down       | Up          | force=true   | behavioral  | Peer unreachable, force=true                | Immediate disable, split-brain warning logged       | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DIS-014| DisableVolumeReplication   | Force disable, peer down                  | Secondary  | Down       | Up          | force=true   | behavioral  | Peer unreachable, force=true                | Emergency disable, cleanup attempted                 | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DIS-015| DisableVolumeReplication   | Force disable, primary array down        | Primary    | Up         | Down        | force=true   | negative    | Primary array unreachable, force=true       | Still fails, cannot force without array access      | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DIS-016| DisableVolumeReplication   | Force disable, secondary array down      | Secondary  | Up         | Down        | force=true   | behavioral  | Secondary array unreachable, force=true     | Forced cleanup, metadata inconsistency warnings     | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| Test ID    | API                      | Scenario                            | Node Role | Peer State | Array State | Params     | Test Type  | Setup/Input                             | Expected Outcome                                       | Notes/Link                                                                                                      |
+| ---------- | ------------------------ | ----------------------------------- | --------- | ---------- | ----------- | ---------- | ---------- | --------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| L1-DIS-009 | DisableVolumeReplication | Force disable, active, peer up      | Primary   | Up         | Up          | force=true | behavioral | Rep enabled, all healthy, force=true    | Immediate disable, volume writeable, warn logged       |                                                                                                                 |
+| L1-DIS-010 | DisableVolumeReplication | Force disable, active, peer up      | Secondary | Up         | Up          | force=true | behavioral | Rep enabled, all healthy, force=true    | Immediate disable, secondary disconnected, warn logged |                                                                                                                 |
+| L1-DIS-011 | DisableVolumeReplication | Force disable, previously disabled  | Primary   | Up         | Up          | force=true | functional | No replication relationship, force=true | Idempotent, no error                                   |                                                                                                                 |
+| L1-DIS-012 | DisableVolumeReplication | Force disable, previously disabled  | Secondary | Up         | Up          | force=true | functional | No replication relationship, force=true | Idempotent, no error                                   |                                                                                                                 |
+| L1-DIS-013 | DisableVolumeReplication | Force disable, peer down            | Primary   | Down       | Up          | force=true | behavioral | Peer unreachable, force=true            | Immediate disable, split-brain warning logged          | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DIS-014 | DisableVolumeReplication | Force disable, peer down            | Secondary | Down       | Up          | force=true | behavioral | Peer unreachable, force=true            | Emergency disable, cleanup attempted                   | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DIS-015 | DisableVolumeReplication | Force disable, primary array down   | Primary   | Up         | Down        | force=true | negative   | Primary array unreachable, force=true   | Still fails, cannot force without array access         | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DIS-016 | DisableVolumeReplication | Force disable, secondary array down | Secondary | Up         | Down        | force=true | behavioral | Secondary array unreachable, force=true | Forced cleanup, metadata inconsistency warnings        | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
 
 **DisableVolumeReplication Test Count: 16 scenarios (8 force=false + 8 force=true)**
 
 ### PromoteVolume (Complete Test Matrix)
 
-| Test ID   | API                    | Scenario                                  | Node Role  | Peer State | Array State | Params      | Test Type  | Setup/Input | Expected Outcome                              | Status | Notes/Link |
-|-----------|------------------------|-------------------------------------------|------------|------------|-------------|-------------|-----------|-------------|-----------------------------------------------|--------|------------|
-| L1-PROM-001| PromoteVolume         | Promote secondary → primary, healthy      | Secondary  | Up         | Up          | force=false | functional| All VRs in sync, healthy                      | VR status.state=Primary, volume RW                  | ✅ IMPLEMENTED | Tested 35.3s |
-| L1-PROM-002| PromoteVolume         | Promote already primary, healthy          | Primary    | Up         | Up          | force=false | functional| Volume already primary                        | Idempotent operation, no change                     | ✅ IMPLEMENTED | Tested 8.2s |
-| L1-PROM-003| PromoteVolume         | Promote secondary, peer down, force=false | Secondary  | Down       | Up          | force=false | negative  | Primary cluster unreachable, attempt promote   | Fails, split-brain prevention active               | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-PROM-004| PromoteVolume         | Promote secondary, peer down, force=true  | Secondary  | Down       | Up          | force=true  | behavioral| Peer down, force emergency failover           | Promoted, warning about possible data loss          | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-PROM-005| PromoteVolume         | Promote, array unreachable, force=false   | Secondary  | Up         | Down        | force=false | negative  | Secondary array disconnected                   | Fails, cannot access volume for promotion          | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-PROM-006| PromoteVolume         | Promote, array unreachable, force=true    | Secondary  | Up         | Down        | force=true  | negative  | Secondary array disconnected, force attempted  | Still fails, cannot promote without array access   | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-PROM-007| PromoteVolume         | Promote with active I/O workload          | Secondary  | Up         | Up          | force=false | behavioral| Active workload on primary                     | Graceful promotion, I/O redirected                 | ✅ IMPLEMENTED | Tested 36.3s |
-| L1-PROM-008| PromoteVolume         | Force promote with active I/O workload    | Secondary  | Up         | Up          | force=true  | behavioral| Active workload, force promotion              | Immediate promotion, potential I/O disruption warning| ✅ IMPLEMENTED | Tested 43.3s |
+| Test ID     | API           | Scenario                                  | Node Role | Peer State | Array State | Params      | Test Type  | Setup/Input                                   | Expected Outcome                                      | Status          | Notes/Link                                                                                    |
+| ----------- | ------------- | ----------------------------------------- | --------- | ---------- | ----------- | ----------- | ---------- | --------------------------------------------- | ----------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------- |
+| L1-PROM-001 | PromoteVolume | Promote secondary → primary, healthy      | Secondary | Up         | Up          | force=false | functional | All VRs in sync, healthy                      | VR status.state=Primary, volume RW                    | ✅ IMPLEMENTED  | Tested 35.3s                                                                                  |
+| L1-PROM-002 | PromoteVolume | Promote already primary, healthy          | Primary   | Up         | Up          | force=false | functional | Volume already primary                        | Idempotent operation, no change                       | ✅ IMPLEMENTED  | Tested 8.2s                                                                                   |
+| L1-PROM-003 | PromoteVolume | Promote secondary, peer down, force=false | Secondary | Down       | Up          | force=false | negative   | Primary cluster unreachable, attempt promote  | Fails, split-brain prevention active                  | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-PROM-004 | PromoteVolume | Promote secondary, peer down, force=true  | Secondary | Down       | Up          | force=true  | behavioral | Peer down, force emergency failover           | Promoted, warning about possible data loss            | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-PROM-005 | PromoteVolume | Promote, array unreachable, force=false   | Secondary | Up         | Down        | force=false | negative   | Secondary array disconnected                  | Fails, cannot access volume for promotion             | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-PROM-006 | PromoteVolume | Promote, array unreachable, force=true    | Secondary | Up         | Down        | force=true  | negative   | Secondary array disconnected, force attempted | Still fails, cannot promote without array access      | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-PROM-007 | PromoteVolume | Promote with active I/O workload          | Secondary | Up         | Up          | force=false | behavioral | Active workload on primary                    | Graceful promotion, I/O redirected                    | ✅ IMPLEMENTED  | Tested 36.3s                                                                                  |
+| L1-PROM-008 | PromoteVolume | Force promote with active I/O workload    | Secondary | Up         | Up          | force=true  | behavioral | Active workload, force promotion              | Immediate promotion, potential I/O disruption warning | ✅ IMPLEMENTED  | Tested 43.3s                                                                                  |
 
 **PromoteVolume Test Count: 8 scenarios (4 implemented, 4 future)**
 
 ### DemoteVolume (Complete Test Matrix)
 
-| Test ID   | API                      | Scenario                                    | Node Role   | Peer State | Array State | Params      | Test Type  | Setup/Input  | Expected Outcome                             | Status | Notes/Link |
-|-----------|--------------------------|---------------------------------------------|-------------|------------|-------------|-------------|-----------|--------------|----------------------------------------------|--------|------------|
-| L1-DEM-001| DemoteVolume             | Demote primary to secondary, healthy        | Primary     | Up         | Up          | force=false | functional| Primary with healthy replication             | VR status.state=Secondary, volume RO         | ✅ IMPLEMENTED | Tested 224s (includes RBD resync) |
-| L1-DEM-002| DemoteVolume             | Demote already secondary, healthy           | Secondary   | Up         | Up          | force=false | functional| Volume already secondary                     | Idempotent operation, no change              | ✅ IMPLEMENTED | Tested 31.3s |
-| L1-DEM-003| DemoteVolume             | Demote primary, peer down, force=false      | Primary     | Down       | Up          | force=false | negative  | Peer unreachable                             | Fails, cannot establish secondary relationship| *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DEM-004| DemoteVolume             | Demote primary, peer down, force=true       | Primary     | Down       | Up          | force=true  | behavioral| Peer down, force demotion                    | Demoted locally, warning about peer state   | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DEM-005| DemoteVolume             | Demote, array unreachable, force=false      | Primary     | Up         | Down        | force=false | negative  | Primary array disconnected                   | Fails, cannot access volume for demotion    | *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DEM-006| DemoteVolume             | Demote, array unreachable, force=true       | Primary     | Up         | Down        | force=true  | negative  | Primary array disconnected, force attempted  | Still fails, cannot demote without array access| *Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-DEM-007| DemoteVolume             | Demote with active I/O workload, force=false| Primary     | Up         | Up          | force=false | behavioral| Active workload, graceful demotion           | Pending I/O completed, then demoted to RO   | ✅ IMPLEMENTED | Tested 212.9s |
-| L1-DEM-008| DemoteVolume             | Force demote with active I/O workload       | Primary     | Up         | Up          | force=true  | behavioral| Active workload, force=true                  | Immediate demotion, pending I/O may be dropped, warning issued | ✅ IMPLEMENTED | Tested 212.9s |
+| Test ID    | API          | Scenario                                     | Node Role | Peer State | Array State | Params      | Test Type  | Setup/Input                                 | Expected Outcome                                               | Status          | Notes/Link                                                                                    |
+| ---------- | ------------ | -------------------------------------------- | --------- | ---------- | ----------- | ----------- | ---------- | ------------------------------------------- | -------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------- |
+| L1-DEM-001 | DemoteVolume | Demote primary to secondary, healthy         | Primary   | Up         | Up          | force=false | functional | Primary with healthy replication            | VR status.state=Secondary, volume RO                           | ✅ IMPLEMENTED  | Tested 224s (includes RBD resync)                                                             |
+| L1-DEM-002 | DemoteVolume | Demote already secondary, healthy            | Secondary | Up         | Up          | force=false | functional | Volume already secondary                    | Idempotent operation, no change                                | ✅ IMPLEMENTED  | Tested 31.3s                                                                                  |
+| L1-DEM-003 | DemoteVolume | Demote primary, peer down, force=false       | Primary   | Down       | Up          | force=false | negative   | Peer unreachable                            | Fails, cannot establish secondary relationship                 | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DEM-004 | DemoteVolume | Demote primary, peer down, force=true        | Primary   | Down       | Up          | force=true  | behavioral | Peer down, force demotion                   | Demoted locally, warning about peer state                      | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DEM-005 | DemoteVolume | Demote, array unreachable, force=false       | Primary   | Up         | Down        | force=false | negative   | Primary array disconnected                  | Fails, cannot access volume for demotion                       | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DEM-006 | DemoteVolume | Demote, array unreachable, force=true        | Primary   | Up         | Down        | force=true  | negative   | Primary array disconnected, force attempted | Still fails, cannot demote without array access                | \*Not Supported | unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-DEM-007 | DemoteVolume | Demote with active I/O workload, force=false | Primary   | Up         | Up          | force=false | behavioral | Active workload, graceful demotion          | Pending I/O completed, then demoted to RO                      | ✅ IMPLEMENTED  | Tested 212.9s                                                                                 |
+| L1-DEM-008 | DemoteVolume | Force demote with active I/O workload        | Primary   | Up         | Up          | force=true  | behavioral | Active workload, force=true                 | Immediate demotion, pending I/O may be dropped, warning issued | ✅ IMPLEMENTED  | Tested 212.9s                                                                                 |
 
 **DemoteVolume Test Count: 8 scenarios (4 implemented, 4 future)**
 
 ### ResyncVolume
 
-| Test ID   | API                    | Scenario                                      | Node Role | Peer State | Params      | Test Type  | Setup/Input  | Expected Outcome                                  | Notes/Link |
-|-----------|------------------------|-----------------------------------------------|-----------|------------|-------------|-----------|--------------|---------------------------------------------------|------------|
-| L1-RSYNC-001| ResyncVolume         | Resync secondary after split-brain            | Secondary | Up         | -           | functional| Split-brain resolved                            | Full resync completes, data consistent             |            |
-| ...       | ...                    | ...                                           | ...       | ...        | ...         | ...       | ...          | ...                                              | ...        |
+| Test ID      | API          | Scenario                           | Node Role | Peer State | Params | Test Type  | Setup/Input          | Expected Outcome                       | Notes/Link |
+| ------------ | ------------ | ---------------------------------- | --------- | ---------- | ------ | ---------- | -------------------- | -------------------------------------- | ---------- |
+| L1-RSYNC-001 | ResyncVolume | Resync secondary after split-brain | Secondary | Up         | -      | functional | Split-brain resolved | Full resync completes, data consistent |            |
+| ...          | ...          | ...                                | ...       | ...        | ...    | ...        | ...                  | ...                                    | ...        |
 
 **ResyncVolume Test Count: 2+ scenarios (expandable)**
 
 ### GetVolumeReplicationInfo
 
-| Test ID   | API                        | Scenario                                    | Node Role | Peer State | Array State | Params      | Test Type  | Setup/Input  | Expected Outcome                                  | Notes/Link |
-|-----------|----------------------------|---------------------------------------------|-----------|------------|-------------|-------------|-----------|--------------|---------------------------------------------------|------------|
-| L1-INFO-001| GetVolumeReplicationInfo  | Query for healthy replication                | Primary   | Up         | Up          | -           | functional| Volume in sync, replication active               | Returns lastSyncTime, status=healthy, replicationHandle | See L1-PROM-002 for related promote scenario |
-| L1-INFO-002| GetVolumeReplicationInfo  | Query for healthy replication on secondary   | Secondary | Up         | Up          | -           | functional| Volume in sync, receiving replication            | Returns lastSyncTime, status=healthy, role=secondary    | See L1-DEM-002 for related demote scenario |
-| L1-INFO-003| GetVolumeReplicationInfo  | Query during sync operation                  | Primary   | Up         | Up          | -           | functional| Sync in progress                                 | Returns status=syncing, progress percentage             |            |
-| L1-INFO-004| GetVolumeReplicationInfo  | Query for degraded replication               | Primary   | Up         | Up          | -           | functional| Network issues, replication lagging              | Returns status=degraded, lastSyncTime old, error details| Related to L1-DIS-005, L1-PROM-003 peer down scenarios |
-| L1-INFO-005| GetVolumeReplicationInfo  | Query with peer unreachable                 | Primary   | Down       | Up          | -           | behavioral| Peer cluster unreachable                         | Returns status=disconnected, connection error details   | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-INFO-006| GetVolumeReplicationInfo  | Query for disabled replication               | Primary   | Up         | Up          | -           | functional| Replication disabled                             | Returns status=disabled, no replicationHandle           | See L1-DIS-001, L1-DIS-002 for disable scenarios |
-| L1-INFO-007| GetVolumeReplicationInfo  | Query with array unreachable                | Primary   | Up         | Down        | -           | behavioral| Storage array disconnected                        | Returns status=error, array connectivity error details  | *Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
-| L1-INFO-008| GetVolumeReplicationInfo  | Query for non-existent volume               | N/A       | Up         | Up          | invalid-vol | negative  | Volume ID that doesn't exist                     | Returns gRPC NotFound error                              |            |
-| L1-INFO-009| GetVolumeReplicationInfo  | Query during split-brain condition          | Primary   | Partial    | Up          | -           | behavioral| Split-brain scenario detected                     | Returns status=split-brain, conflict details            | Related to L1-PROM-004, L1-DIS-013 force scenarios |
-| L1-INFO-010| GetVolumeReplicationInfo  | Query for never-enabled replication         | Primary   | Up         | Up          | -           | functional| Volume never had replication enabled             | Returns status=not-configured, no replication metadata  |            |
-| L1-INFO-011| GetVolumeReplicationInfo  | Query after invalid mirroringMode error     | Primary   | Up         | Up          | -           | functional| Enable failed due to invalid mirroringMode      | Returns status=not-configured, no replication metadata  | See L1-E-007 for related enable error |
-| L1-INFO-012| GetVolumeReplicationInfo  | Query after invalid interval parameter error| Primary   | Up         | Up          | -           | functional| Enable failed due to bad interval parameter     | Returns status=not-configured, no replication metadata  | See L1-E-004 for related enable error |
-| L1-INFO-013| GetVolumeReplicationInfo  | Query after secret reference error          | Primary   | Up         | Up          | -           | functional| Enable failed due to missing/invalid secret     | Returns status=error, FailedPrecondition details       | See L1-E-006 for related enable error |
-| L1-INFO-014| GetVolumeReplicationInfo  | Query after invalid time format error       | Primary   | Up         | Up          | -           | functional| Enable failed due to bad schedulingStartTime    | Returns status=not-configured, no replication metadata  | See L1-E-009 for related enable error |
+| Test ID     | API                      | Scenario                                     | Node Role | Peer State | Array State | Params      | Test Type  | Setup/Input                                  | Expected Outcome                                         | Notes/Link                                                                                                      |
+| ----------- | ------------------------ | -------------------------------------------- | --------- | ---------- | ----------- | ----------- | ---------- | -------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| L1-INFO-001 | GetVolumeReplicationInfo | Query for healthy replication                | Primary   | Up         | Up          | -           | functional | Volume in sync, replication active           | Returns lastSyncTime, status=healthy, replicationHandle  | See L1-PROM-002 for related promote scenario                                                                    |
+| L1-INFO-002 | GetVolumeReplicationInfo | Query for healthy replication on secondary   | Secondary | Up         | Up          | -           | functional | Volume in sync, receiving replication        | Returns lastSyncTime, status=healthy, role=secondary     | See L1-DEM-002 for related demote scenario                                                                      |
+| L1-INFO-003 | GetVolumeReplicationInfo | Query during sync operation                  | Primary   | Up         | Up          | -           | functional | Sync in progress                             | Returns status=syncing, progress percentage              |                                                                                                                 |
+| L1-INFO-004 | GetVolumeReplicationInfo | Query for degraded replication               | Primary   | Up         | Up          | -           | functional | Network issues, replication lagging          | Returns status=degraded, lastSyncTime old, error details | Related to L1-DIS-005, L1-PROM-003 peer down scenarios                                                          |
+| L1-INFO-005 | GetVolumeReplicationInfo | Query with peer unreachable                  | Primary   | Down       | Up          | -           | behavioral | Peer cluster unreachable                     | Returns status=disconnected, connection error details    | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-INFO-006 | GetVolumeReplicationInfo | Query for disabled replication               | Primary   | Up         | Up          | -           | functional | Replication disabled                         | Returns status=disabled, no replicationHandle            | See L1-DIS-001, L1-DIS-002 for disable scenarios                                                                |
+| L1-INFO-007 | GetVolumeReplicationInfo | Query with array unreachable                 | Primary   | Up         | Down        | -           | behavioral | Storage array disconnected                   | Returns status=error, array connectivity error details   | \*Not Supported - unreachable storage not supported in current K8s CSI tests will be implemented in later stage |
+| L1-INFO-008 | GetVolumeReplicationInfo | Query for non-existent volume                | N/A       | Up         | Up          | invalid-vol | negative   | Volume ID that doesn't exist                 | Returns gRPC NotFound error                              |                                                                                                                 |
+| L1-INFO-009 | GetVolumeReplicationInfo | Query during split-brain condition           | Primary   | Partial    | Up          | -           | behavioral | Split-brain scenario detected                | Returns status=split-brain, conflict details             | Related to L1-PROM-004, L1-DIS-013 force scenarios                                                              |
+| L1-INFO-010 | GetVolumeReplicationInfo | Query for never-enabled replication          | Primary   | Up         | Up          | -           | functional | Volume never had replication enabled         | Returns status=not-configured, no replication metadata   |                                                                                                                 |
+| L1-INFO-011 | GetVolumeReplicationInfo | Query after invalid mirroringMode error      | Primary   | Up         | Up          | -           | functional | Enable failed due to invalid mirroringMode   | Returns status=not-configured, no replication metadata   | See L1-E-007 for related enable error                                                                           |
+| L1-INFO-012 | GetVolumeReplicationInfo | Query after invalid interval parameter error | Primary   | Up         | Up          | -           | functional | Enable failed due to bad interval parameter  | Returns status=not-configured, no replication metadata   | See L1-E-004 for related enable error                                                                           |
+| L1-INFO-013 | GetVolumeReplicationInfo | Query after secret reference error           | Primary   | Up         | Up          | -           | functional | Enable failed due to missing/invalid secret  | Returns status=error, FailedPrecondition details         | See L1-E-006 for related enable error                                                                           |
+| L1-INFO-014 | GetVolumeReplicationInfo | Query after invalid time format error        | Primary   | Up         | Up          | -           | functional | Enable failed due to bad schedulingStartTime | Returns status=not-configured, no replication metadata   | See L1-E-009 for related enable error                                                                           |
 
 **GetVolumeReplicationInfo Test Count: 14 scenarios**
 
 **Total VolumeReplication API Test Count: 57+ scenarios**
+
 - EnableVolumeReplication: 9 scenarios
 - DisableVolumeReplication: 16 scenarios
 - PromoteVolume: 8 scenarios
@@ -972,126 +1039,128 @@ The full test plan below enumerates all endpoint, state, and workflow-driven sce
 - ResyncVolume: 2+ scenarios
 - GetVolumeReplicationInfo: 14 scenarios
 
-*Note: Tests marked with "Not Supported" involve unreachable storage/cluster scenarios that are not supported in the current Kubernetes CSI test framework and will be implemented in later stage. See [disruptive tests documentation](https://github.com/nadavleva/kubernetes_csiaddontests/blob/docs/storage-test-framework/test/e2e/storage/README.md#disruptive-tests) for details.*
+_Note: Tests marked with "Not Supported" involve unreachable storage/cluster scenarios that are not supported in the current Kubernetes CSI test framework and will be implemented in later stage. See [disruptive tests documentation](https://github.com/nadavleva/kubernetes_csiaddontests/blob/docs/storage-test-framework/test/end-to-end/storage/README.md#disruptive-tests) for details._
 
 ### Volume Group Operations (using VolumeReplication gRPC APIs with replicationsource field)
 
-*Volume group replication uses the same VolumeReplication gRPC APIs (EnableVolumeReplication, DisableVolumeReplication, PromoteVolume, DemoteVolume, etc.) with the **replicationsource** field to specify group membership.*
+_Volume group replication uses the same VolumeReplication gRPC APIs (EnableVolumeReplication, DisableVolumeReplication, PromoteVolume, DemoteVolume, etc.) with the **replicationsource** field to specify group membership._
 
 **Important**: VolumeReplicationGroup (VRG) Kubernetes CRD tests are **not in scope for Phase 1**. The following focuses on Volume Group operations using CSI gRPC APIs only.
 
-| Test ID   | RPC API                    | Scenario                                    | Group State | Params          | Test Type   | Setup/Input                                    | Expected Outcome                                          | Notes/Link             |
-|-----------|----------------------------|---------------------------------------------|-------------|-----------------|-------------|------------------------------------------------|-----------------------------------------------------------|------------------------|
-| L1-GRP-001| EnableVolumeReplication    | Enable replication for volume group         | All disabled| replicationsource=group1 | functional  | 3 volumes in group, all healthy                | All volumes in group enabled for replication             |                        |
-| L1-GRP-002| DisableVolumeReplication   | Disable replication for volume group        | All enabled | replicationsource=group1 | functional  | 3 volumes in group, all replicating            | All volumes in group disabled, group consistent          |                        |
-| L1-GRP-003| PromoteVolume              | Promote volume group to primary             | Secondary   | replicationsource=group1 | functional  | Volume group in secondary state                | All volumes in group promoted to primary                 |                        |
-| L1-GRP-004| DemoteVolume               | Demote volume group to secondary            | Primary     | replicationsource=group1 | functional  | Volume group in primary state                  | All volumes in group demoted to secondary                |                        |
-| L1-GRP-005| EnableVolumeReplication    | Enable group with mixed volume states       | Mixed       | replicationsource=group1 | negative    | Some volumes enabled, some disabled            | Operation fails, group state inconsistent                |                        |
-| L1-GRP-006| DisableVolumeReplication   | Force disable group, peer unreachable       | Enabled     | replicationsource=group1, force=true | behavioral | Group enabled, peer cluster down              | Group disabled with warnings, split-brain risk           |                        |
+| Test ID    | RPC API                  | Scenario                              | Group State  | Params                               | Test Type  | Setup/Input                         | Expected Outcome                                | Notes/Link |
+| ---------- | ------------------------ | ------------------------------------- | ------------ | ------------------------------------ | ---------- | ----------------------------------- | ----------------------------------------------- | ---------- |
+| L1-GRP-001 | EnableVolumeReplication  | Enable replication for volume group   | All disabled | replicationsource=group1             | functional | 3 volumes in group, all healthy     | All volumes in group enabled for replication    |            |
+| L1-GRP-002 | DisableVolumeReplication | Disable replication for volume group  | All enabled  | replicationsource=group1             | functional | 3 volumes in group, all replicating | All volumes in group disabled, group consistent |            |
+| L1-GRP-003 | PromoteVolume            | Promote volume group to primary       | Secondary    | replicationsource=group1             | functional | Volume group in secondary state     | All volumes in group promoted to primary        |            |
+| L1-GRP-004 | DemoteVolume             | Demote volume group to secondary      | Primary      | replicationsource=group1             | functional | Volume group in primary state       | All volumes in group demoted to secondary       |            |
+| L1-GRP-005 | EnableVolumeReplication  | Enable group with mixed volume states | Mixed        | replicationsource=group1             | negative   | Some volumes enabled, some disabled | Operation fails, group state inconsistent       |            |
+| L1-GRP-006 | DisableVolumeReplication | Force disable group, peer unreachable | Enabled      | replicationsource=group1, force=true | behavioral | Group enabled, peer cluster down    | Group disabled with warnings, split-brain risk  |            |
 
 **Volume Group Operations Test Count: 6 scenarios (Phase 1 - using VolumeReplication gRPC APIs)**
 
 ### VolumeReplicationGroup (VRG) CRD Operations - Out of Scope for Phase 1
 
-*The following VRG CRD-based operations are not included in Phase 1 testing scope:*
+_The following VRG CRD-based operations are not included in Phase 1 testing scope:_
 
 #### VRG Disable Operations - Core Scenarios
 
 **Active Replication (Both Sides Alive) - force=false**
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|-------------|-------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DIS-001 | VRG Disable   | Disable on primary, active replication           | Active        | Active          | Up        | P:Up/S:Up   | force=false | functional | Active VRG with healthy replication             | VRG disabled, replication stopped, primary writable       |            |
-| L1-VRG-DIS-002 | VRG Disable   | Disable on secondary, active replication         | Active        | Active          | Up        | P:Up/S:Up   | force=false | functional | Active VRG with healthy replication             | VRG disabled, replication stopped, secondary remains RO   |            |
+| Test ID        | API Operation | Scenario                                 | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                         | Expected Outcome                                        | Notes/Link |
+| -------------- | ------------- | ---------------------------------------- | ------------- | --------------- | --------- | ----------- | ----------- | ---------- | ----------------------------------- | ------------------------------------------------------- | ---------- |
+| L1-VRG-DIS-001 | VRG Disable   | Disable on primary, active replication   | Active        | Active          | Up        | P:Up/S:Up   | force=false | functional | Active VRG with healthy replication | VRG disabled, replication stopped, primary writable     |            |
+| L1-VRG-DIS-002 | VRG Disable   | Disable on secondary, active replication | Active        | Active          | Up        | P:Up/S:Up   | force=false | functional | Active VRG with healthy replication | VRG disabled, replication stopped, secondary remains RO |            |
 
 **Previously Disabled Replication (Both Sides Alive) - force=false**
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|-------------|-------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DIS-003 | VRG Disable   | Disable on primary, previously disabled          | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=false | functional | VRG exists but replication already disabled     | Idempotent operation, no error                             |            |
-| L1-VRG-DIS-004 | VRG Disable   | Disable on secondary, previously disabled        | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=false | functional | VRG exists but replication already disabled     | Idempotent operation, no error                             |            |
+| Test ID        | API Operation | Scenario                                  | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                                 | Expected Outcome               | Notes/Link |
+| -------------- | ------------- | ----------------------------------------- | ------------- | --------------- | --------- | ----------- | ----------- | ---------- | ------------------------------------------- | ------------------------------ | ---------- |
+| L1-VRG-DIS-003 | VRG Disable   | Disable on primary, previously disabled   | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=false | functional | VRG exists but replication already disabled | Idempotent operation, no error |            |
+| L1-VRG-DIS-004 | VRG Disable   | Disable on secondary, previously disabled | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=false | functional | VRG exists but replication already disabled | Idempotent operation, no error |            |
 
 **Broken Replication (Peer Dead) - force=false**
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|-------------|-------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DIS-005 | VRG Disable   | Disable on primary, peer dead                    | Active        | Unknown         | Down      | P:Up/S:?    | force=false | negative   | Network partition, secondary cluster unreachable| Operation fails, appropriate timeout/error in status      |            |
-| L1-VRG-DIS-006 | VRG Disable   | Disable on secondary, peer dead                  | Unknown       | Active          | Down      | P:?/S:Up    | force=false | negative   | Network partition, primary cluster unreachable | Operation fails, split-brain protection active            |            |
+| Test ID        | API Operation | Scenario                        | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type | Setup/Input                                      | Expected Outcome                                     | Notes/Link |
+| -------------- | ------------- | ------------------------------- | ------------- | --------------- | --------- | ----------- | ----------- | --------- | ------------------------------------------------ | ---------------------------------------------------- | ---------- |
+| L1-VRG-DIS-005 | VRG Disable   | Disable on primary, peer dead   | Active        | Unknown         | Down      | P:Up/S:?    | force=false | negative  | Network partition, secondary cluster unreachable | Operation fails, appropriate timeout/error in status |            |
+| L1-VRG-DIS-006 | VRG Disable   | Disable on secondary, peer dead | Unknown       | Active          | Down      | P:?/S:Up    | force=false | negative  | Network partition, primary cluster unreachable   | Operation fails, split-brain protection active       |            |
 
 **Array Unreachable - force=false**
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|-------------|-------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DIS-007 | VRG Disable   | Disable on primary, primary array unreachable    | Unknown       | Active          | Up        | P:Down/S:Up | force=false | negative   | Primary storage array disconnected              | Operation fails, cannot access primary volume metadata    |            |
-| L1-VRG-DIS-008 | VRG Disable   | Disable on secondary, secondary array unreachable| Active        | Unknown         | Up        | P:Up/S:Down | force=false | negative   | Secondary storage array disconnected            | Operation fails, cannot clean up secondary resources      |            |
+| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params      | Test Type | Setup/Input                          | Expected Outcome                                       | Notes/Link |
+| -------------- | ------------- | ------------------------------------------------- | ------------- | --------------- | --------- | ----------- | ----------- | --------- | ------------------------------------ | ------------------------------------------------------ | ---------- |
+| L1-VRG-DIS-007 | VRG Disable   | Disable on primary, primary array unreachable     | Unknown       | Active          | Up        | P:Down/S:Up | force=false | negative  | Primary storage array disconnected   | Operation fails, cannot access primary volume metadata |            |
+| L1-VRG-DIS-008 | VRG Disable   | Disable on secondary, secondary array unreachable | Active        | Unknown         | Up        | P:Up/S:Down | force=false | negative  | Secondary storage array disconnected | Operation fails, cannot clean up secondary resources   |            |
 
 **VRG Disable Operations - With force=true**
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | Array State | Params     | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|-------------|------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DIS-009 | VRG Disable   | Force disable on primary, active replication     | Active        | Active          | Up        | P:Up/S:Up   | force=true | behavioral | Active VRG, force immediate disable             | Immediate disable, potential data loss warning logged     |            |
-| L1-VRG-DIS-010 | VRG Disable   | Force disable on secondary, active replication   | Active        | Active          | Up        | P:Up/S:Up   | force=true | behavioral | Active VRG, force immediate disable             | Immediate disable, secondary disconnected                  |            |
-| L1-VRG-DIS-011 | VRG Disable   | Force disable on primary, previously disabled    | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=true | functional | VRG exists but replication already disabled     | Idempotent operation, no error                             |            |
-| L1-VRG-DIS-012 | VRG Disable   | Force disable on secondary, previously disabled | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=true | functional | VRG exists but replication already disabled     | Idempotent operation, no error                             |            |
-| L1-VRG-DIS-013 | VRG Disable   | Force disable on primary, peer dead              | Active        | Unknown         | Down      | P:Up/S:?    | force=true | behavioral | Network partition, force override               | Primary disabled immediately, split-brain warning           |            |
-| L1-VRG-DIS-014 | VRG Disable   | Force disable on secondary, peer dead            | Unknown       | Active          | Down      | P:?/S:Up    | force=true | behavioral | Network partition, force override               | Secondary disabled, emergency cleanup                     |            |
-| L1-VRG-DIS-015 | VRG Disable   | Force disable on primary, primary array down     | Unknown       | Active          | Up        | P:Down/S:Up | force=true | negative   | Primary array disconnected, force attempted     | Still fails, cannot force without array access             |            |
-| L1-VRG-DIS-016 | VRG Disable   | Force disable on secondary, secondary array down | Active        | Unknown         | Up        | P:Up/S:Down | force=true | behavioral | Secondary array disconnected, force cleanup     | Forced cleanup, metadata inconsistency warnings           |            |
+| Test ID        | API Operation | Scenario                                         | Primary State | Secondary State | Peer Conn | Array State | Params     | Test Type  | Setup/Input                                 | Expected Outcome                                      | Notes/Link |
+| -------------- | ------------- | ------------------------------------------------ | ------------- | --------------- | --------- | ----------- | ---------- | ---------- | ------------------------------------------- | ----------------------------------------------------- | ---------- |
+| L1-VRG-DIS-009 | VRG Disable   | Force disable on primary, active replication     | Active        | Active          | Up        | P:Up/S:Up   | force=true | behavioral | Active VRG, force immediate disable         | Immediate disable, potential data loss warning logged |            |
+| L1-VRG-DIS-010 | VRG Disable   | Force disable on secondary, active replication   | Active        | Active          | Up        | P:Up/S:Up   | force=true | behavioral | Active VRG, force immediate disable         | Immediate disable, secondary disconnected             |            |
+| L1-VRG-DIS-011 | VRG Disable   | Force disable on primary, previously disabled    | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=true | functional | VRG exists but replication already disabled | Idempotent operation, no error                        |            |
+| L1-VRG-DIS-012 | VRG Disable   | Force disable on secondary, previously disabled  | Disabled      | Disabled        | Up        | P:Up/S:Up   | force=true | functional | VRG exists but replication already disabled | Idempotent operation, no error                        |            |
+| L1-VRG-DIS-013 | VRG Disable   | Force disable on primary, peer dead              | Active        | Unknown         | Down      | P:Up/S:?    | force=true | behavioral | Network partition, force override           | Primary disabled immediately, split-brain warning     |            |
+| L1-VRG-DIS-014 | VRG Disable   | Force disable on secondary, peer dead            | Unknown       | Active          | Down      | P:?/S:Up    | force=true | behavioral | Network partition, force override           | Secondary disabled, emergency cleanup                 |            |
+| L1-VRG-DIS-015 | VRG Disable   | Force disable on primary, primary array down     | Unknown       | Active          | Up        | P:Down/S:Up | force=true | negative   | Primary array disconnected, force attempted | Still fails, cannot force without array access        |            |
+| L1-VRG-DIS-016 | VRG Disable   | Force disable on secondary, secondary array down | Active        | Unknown         | Up        | P:Up/S:Down | force=true | behavioral | Secondary array disconnected, force cleanup | Forced cleanup, metadata inconsistency warnings       |            |
 
 **VRG Disable Operations Test Count: 16 scenarios (8 force=false + 8 force=true) - Out of Scope for Phase 1**
 
 #### VRG Creation and Lifecycle Operations
 
-| Test ID        | API Operation | Scenario                                          | Cluster State | PVC State   | S3 State | Params         | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-------------|----------|----------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-CRE-001 | VRG Create    | Create VRG for single PVC, healthy clusters      | Both Up       | Bound       | Up       | -              | functional | Valid PVC, both clusters healthy                | VRG created, VR resources provisioned                     |            |
-| L1-VRG-CRE-002 | VRG Create    | Create VRG for multiple PVCs, healthy clusters   | Both Up       | Multiple    | Up       | -              | functional | Multiple matching PVCs                          | VRG created, multiple VR resources                         |            |
-| L1-VRG-CRE-003 | VRG Create    | Create VRG, secondary cluster unreachable        | P:Up/S:Down   | Bound       | Up       | -              | negative   | Secondary cluster network failure               | VRG creation delayed/degraded state                        |            |
-| L1-VRG-CRE-004 | VRG Create    | Create VRG, S3 unreachable                       | Both Up       | Bound       | Down     | -              | negative   | S3 metadata store unavailable                   | VRG creation fails, cannot store metadata                 |            |
-| L1-VRG-CRE-005 | VRG Create    | Create VRG, invalid PVC selector                 | Both Up       | None        | Up       | bad-selector   | negative   | PVC selector matches no resources               | VRG created but no VR resources, appropriate status       |            |
+| Test ID        | API Operation | Scenario                                       | Cluster State | PVC State | S3 State | Params       | Test Type  | Setup/Input                       | Expected Outcome                                    | Notes/Link |
+| -------------- | ------------- | ---------------------------------------------- | ------------- | --------- | -------- | ------------ | ---------- | --------------------------------- | --------------------------------------------------- | ---------- |
+| L1-VRG-CRE-001 | VRG Create    | Create VRG for single PVC, healthy clusters    | Both Up       | Bound     | Up       | -            | functional | Valid PVC, both clusters healthy  | VRG created, VR resources provisioned               |            |
+| L1-VRG-CRE-002 | VRG Create    | Create VRG for multiple PVCs, healthy clusters | Both Up       | Multiple  | Up       | -            | functional | Multiple matching PVCs            | VRG created, multiple VR resources                  |            |
+| L1-VRG-CRE-003 | VRG Create    | Create VRG, secondary cluster unreachable      | P:Up/S:Down   | Bound     | Up       | -            | negative   | Secondary cluster network failure | VRG creation delayed/degraded state                 |            |
+| L1-VRG-CRE-004 | VRG Create    | Create VRG, S3 unreachable                     | Both Up       | Bound     | Down     | -            | negative   | S3 metadata store unavailable     | VRG creation fails, cannot store metadata           |            |
+| L1-VRG-CRE-005 | VRG Create    | Create VRG, invalid PVC selector               | Both Up       | None      | Up       | bad-selector | negative   | PVC selector matches no resources | VRG created but no VR resources, appropriate status |            |
 
 **VRG Creation and Lifecycle Operations Test Count: 5 scenarios - Out of Scope for Phase 1**
 
 #### VRG Failover and Failback Operations
 
-| Test ID        | API Operation | Scenario                                          | Primary State | Secondary State | Peer Conn | S3 State | Params            | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-----------------|-----------|----------|-------------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-FAIL-001| VRG Failover  | Emergency failover, primary cluster down         | Down          | Active          | Down      | Up       | action=Failover   | functional | Primary cluster failure simulation              | Secondary promoted to primary, data accessible            |            |
-| L1-VRG-FAIL-002| VRG Failover  | Planned failover, both clusters healthy          | Active        | Active          | Up        | Up       | action=Failover   | functional | Graceful planned failover                       | Clean role switch, minimal downtime                       |            |
-| L1-VRG-FAIL-003| VRG Failback  | Failback after primary recovery                  | Recovered     | Primary         | Up        | Up       | action=Failback   | functional | Primary cluster restored after failure          | Original primary restored, data consistent                 |            |
-| L1-VRG-FAIL-004| VRG Failover  | Split-brain scenario, force failover             | Isolated      | Isolated        | Partial   | Up       | action=Failover   | behavioral| Network split causing isolation                 | Emergency promotion with split-brain warnings             |            |
+| Test ID         | API Operation | Scenario                                 | Primary State | Secondary State | Peer Conn | S3 State | Params          | Test Type  | Setup/Input                            | Expected Outcome                               | Notes/Link |
+| --------------- | ------------- | ---------------------------------------- | ------------- | --------------- | --------- | -------- | --------------- | ---------- | -------------------------------------- | ---------------------------------------------- | ---------- |
+| L1-VRG-FAIL-001 | VRG Failover  | Emergency failover, primary cluster down | Down          | Active          | Down      | Up       | action=Failover | functional | Primary cluster failure simulation     | Secondary promoted to primary, data accessible |            |
+| L1-VRG-FAIL-002 | VRG Failover  | Planned failover, both clusters healthy  | Active        | Active          | Up        | Up       | action=Failover | functional | Graceful planned failover              | Clean role switch, minimal downtime            |            |
+| L1-VRG-FAIL-003 | VRG Failback  | Failback after primary recovery          | Recovered     | Primary         | Up        | Up       | action=Failback | functional | Primary cluster restored after failure | Original primary restored, data consistent     |            |
+| L1-VRG-FAIL-004 | VRG Failover  | Split-brain scenario, force failover     | Isolated      | Isolated        | Partial   | Up       | action=Failover | behavioral | Network split causing isolation        | Emergency promotion with split-brain warnings  |            |
 
 #### VRG Status and Monitoring Operations
 
-| Test ID        | API Operation | Scenario                                          | Replication State | Sync Status | Error State | Params | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|-------------------|-------------|-------------|--------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-STAT-001| VRG Status    | Query status, healthy replication                | Active            | InSync      | None        | -      | functional | Normal replication operation                    | Status shows healthy, lastSyncTime current                |            |
-| L1-VRG-STAT-002| VRG Status    | Query status, sync in progress                   | Active            | Syncing     | None        | -      | functional | Replication sync operation ongoing              | Status shows sync progress, estimated completion          |            |
-| L1-VRG-STAT-003| VRG Status    | Query status, error condition                    | Degraded          | OutOfSync   | NetworkError| -      | functional | Network issues affecting replication            | Status shows error details, troubleshooting info          |            |
+| Test ID         | API Operation | Scenario                          | Replication State | Sync Status | Error State  | Params | Test Type  | Setup/Input                          | Expected Outcome                                 | Notes/Link |
+| --------------- | ------------- | --------------------------------- | ----------------- | ----------- | ------------ | ------ | ---------- | ------------------------------------ | ------------------------------------------------ | ---------- |
+| L1-VRG-STAT-001 | VRG Status    | Query status, healthy replication | Active            | InSync      | None         | -      | functional | Normal replication operation         | Status shows healthy, lastSyncTime current       |            |
+| L1-VRG-STAT-002 | VRG Status    | Query status, sync in progress    | Active            | Syncing     | None         | -      | functional | Replication sync operation ongoing   | Status shows sync progress, estimated completion |            |
+| L1-VRG-STAT-003 | VRG Status    | Query status, error condition     | Degraded          | OutOfSync   | NetworkError | -      | functional | Network issues affecting replication | Status shows error details, troubleshooting info |            |
 
 #### VRG Deletion and Cleanup Operations
 
-| Test ID        | API Operation | Scenario                                          | VRG State     | VR State    | S3 State | Finalizers | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|-------------|----------|------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-DEL-001 | VRG Delete    | Delete VRG, all resources healthy                | Active        | Multiple    | Up       | Present    | functional | VRG with active VR resources                    | VRG deleted, all VRs cleaned up, finalizers cleared       |            |
-| L1-VRG-DEL-002 | VRG Delete    | Delete VRG, S3 unavailable                       | Active        | Multiple    | Down     | Present    | negative   | S3 metadata store unreachable                   | Deletion blocked, finalizer remains, cleanup pending      |            |
-| L1-VRG-DEL-003 | VRG Delete    | Delete VRG, peer cluster unreachable             | Active        | Multiple    | Up       | Present    | behavioral | Secondary cluster network failure               | Local cleanup, remote cleanup marked for retry            |            |
-| L1-VRG-DEL-004 | VRG Delete    | Force delete VRG, resources stuck                | Terminating   | Stuck       | Up       | Stuck      | behavioral | VR resources cannot be cleaned normally         | Force deletion, resource leakage warnings                 |            |
+| Test ID        | API Operation | Scenario                             | VRG State   | VR State | S3 State | Finalizers | Test Type  | Setup/Input                             | Expected Outcome                                     | Notes/Link |
+| -------------- | ------------- | ------------------------------------ | ----------- | -------- | -------- | ---------- | ---------- | --------------------------------------- | ---------------------------------------------------- | ---------- |
+| L1-VRG-DEL-001 | VRG Delete    | Delete VRG, all resources healthy    | Active      | Multiple | Up       | Present    | functional | VRG with active VR resources            | VRG deleted, all VRs cleaned up, finalizers cleared  |            |
+| L1-VRG-DEL-002 | VRG Delete    | Delete VRG, S3 unavailable           | Active      | Multiple | Down     | Present    | negative   | S3 metadata store unreachable           | Deletion blocked, finalizer remains, cleanup pending |            |
+| L1-VRG-DEL-003 | VRG Delete    | Delete VRG, peer cluster unreachable | Active      | Multiple | Up       | Present    | behavioral | Secondary cluster network failure       | Local cleanup, remote cleanup marked for retry       |            |
+| L1-VRG-DEL-004 | VRG Delete    | Force delete VRG, resources stuck    | Terminating | Stuck    | Up       | Stuck      | behavioral | VR resources cannot be cleaned normally | Force deletion, resource leakage warnings            |            |
 
 #### VRG Cross-Namespace and Multi-Cluster Scenarios
 
-| Test ID        | API Operation | Scenario                                          | Namespace     | PVC Location | Cluster Config | Test Type  | Setup/Input                                     | Expected Outcome                                           | Notes/Link |
-|----------------|---------------|---------------------------------------------------|---------------|--------------|----------------|------------|-------------------------------------------------|------------------------------------------------------------|------------|
-| L1-VRG-NS-001  | VRG Create    | VRG in different namespace than PVCs              | Different     | ns1/ns2      | Standard       | functional | VRG in ns-a, PVCs in ns-b                       | Cross-namespace selection works correctly                  |            |
-| L1-VRG-NS-002  | VRG Create    | VRG with PVCs across multiple namespaces         | Multiple      | Multiple     | Standard       | functional | PVC selector spans namespaces                   | All matching PVCs selected regardless of namespace        |            |
-| L1-VRG-MC-001  | VRG Create    | VRG on cluster with different storage classes    | Standard      | Mixed SC     | Heterogeneous  | behavioral | Primary/secondary use different storage         | VRG handles storage class differences gracefully          |            |
+| Test ID       | API Operation | Scenario                                      | Namespace | PVC Location | Cluster Config | Test Type  | Setup/Input                             | Expected Outcome                                   | Notes/Link |
+| ------------- | ------------- | --------------------------------------------- | --------- | ------------ | -------------- | ---------- | --------------------------------------- | -------------------------------------------------- | ---------- |
+| L1-VRG-NS-001 | VRG Create    | VRG in different namespace than PVCs          | Different | ns1/ns2      | Standard       | functional | VRG in ns-a, PVCs in ns-b               | Cross-namespace selection works correctly          |            |
+| L1-VRG-NS-002 | VRG Create    | VRG with PVCs across multiple namespaces      | Multiple  | Multiple     | Standard       | functional | PVC selector spans namespaces           | All matching PVCs selected regardless of namespace |            |
+| L1-VRG-MC-001 | VRG Create    | VRG on cluster with different storage classes | Standard  | Mixed SC     | Heterogeneous  | behavioral | Primary/secondary use different storage | VRG handles storage class differences gracefully   |            |
 
 **Total VRG Test Count Summary:**
 
 **Phase 1 - In Scope (Volume Group Operations using gRPC APIs):**
+
 - Volume Group Operations: 6 scenarios
 
 **Out of Scope for Phase 1 (VRG Kubernetes CRD Operations):**
+
 - VRG Disable Operations: 16 scenarios
 - VRG Creation/Lifecycle: 5 scenarios
 - VRG Failover/Failback: 4+ scenarios

--- a/hack/run-replication-e2e.sh
+++ b/hack/run-replication-e2e.sh
@@ -25,6 +25,8 @@
 #                             Default: "v" (verbose) plus show-node-events and trace on failure.
 #   IPTABLES_IMAGE          - Container image for iptables fault injection (default: alpine:3.19).
 #                             Used by dual-cluster tests with network fault injection.
+#   E2E_FAULT_INJECTOR      - Fault injection backend: iptables (default if unset), networkfence, or none.
+#                             Passed to tests; L1-E-003 and other fence tests honor this.
 #
 # Examples:
 #   ./hack/run-replication-e2e.sh
@@ -46,6 +48,8 @@ CLEANUP_SCRIPT="${SCRIPT_DIR}/clean-replication-e2e-resources.sh"
 mkdir -p "${LOGS_DIR}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 LOG_FILE="${LOGS_DIR}/replication-e2e_${TIMESTAMP}.log"
+# Mirror everything below to the log file. Makefile output (manifests, generate, fmt, vet) runs before this script and appears on the terminal only.
+exec > >(tee -a "${LOG_FILE}") 2>&1
 INSTALL_CRDS="${INSTALL_CRDS:-false}"
 REPLICATION_TEST_TIMEOUT="${REPLICATION_TEST_TIMEOUT:-30m}"
 GINKGO_VERBOSE="${GINKGO_VERBOSE:-v}"
@@ -53,6 +57,7 @@ EXIT_CODE=1
 CLEANUP_ON_EXIT=0
 
 # Run cleanup on exit (success, failure, or panic/timeout) so PVCs/VRs are not left behind.
+# shellcheck disable=SC2317  # Function is called via trap
 run_cleanup_on_exit() {
 	if [[ "$CLEANUP_ON_EXIT" == "1" ]] && [[ -x "$CLEANUP_SCRIPT" ]]; then
 		echo ""
@@ -128,7 +133,20 @@ echo "  CSI_PROVISIONER=${CSI_PROVISIONER:-rook-ceph.rbd.csi.ceph.com}"
 echo "  DR1_CONTEXT=${DR1_CONTEXT:-<unset>}"
 echo "  DR2_CONTEXT=${DR2_CONTEXT:-<unset>}"
 echo "  IPTABLES_IMAGE=${IPTABLES_IMAGE:-csi-addons/iptables-manager:latest}"
-echo "  GINKGO_FOCUS=${GINKGO_FOCUS:-<all>}"
+echo "  GINKGO_VERBOSE=${GINKGO_VERBOSE:-v}"
+echo "  E2E_FAULT_INJECTOR=${E2E_FAULT_INJECTOR:-<default iptables>}"
+echo "  E2E_IPTABLES_IMAGE=(exported before go test; see Full environment after iptables prep)"
+echo "  FENCE_TARGET_SERVICES=${FENCE_TARGET_SERVICES:-<unset>}"
+echo "  FENCE_PEER_SERVICES=${FENCE_PEER_SERVICES:-<unset>}"
+echo "  FENCE_CIDRS=${FENCE_CIDRS:-<unset>}"
+echo "  FENCE_CLUSTER_ID=${FENCE_CLUSTER_ID:-<unset>}"
+echo "  FENCE_AUTO_ENDPOINT_NAMESPACES=${FENCE_AUTO_ENDPOINT_NAMESPACES:-<unset>}"
+echo "  INSTALL_CRDS=${INSTALL_CRDS}"
+echo "  GINKGO_SKIP=${GINKGO_SKIP:-<none>}"
+echo "  E2E_IPTABLES_SKIP_SUITE_DS_RECREATE=${E2E_IPTABLES_SKIP_SUITE_DS_RECREATE:-<unset>}"
+echo "  E2E_IPTABLES_DAEMONSET_NAMESPACE=${E2E_IPTABLES_DAEMONSET_NAMESPACE:-<default csi-addons-system>}"
+echo "  E2E_IPTABLES_DAEMONSET_NAME=${E2E_IPTABLES_DAEMONSET_NAME:-<default csi-addons-iptables-manager>}"
+echo "  USE_EXISTING_CLUSTER=true (set by this script for go test)"
 echo ""
 
 echo "[3/5] Checking VolumeReplication CRD..."
@@ -146,52 +164,62 @@ else
 fi
 echo ""
 
-echo "[3.5/6] Preparing iptables image for fault injection..."
+# Only build/load iptables image when tests use the iptables injector (unset defaults to iptables). Skip for networkfence / none.
+E2E_FAULT_INJECTOR_LOWER="$(printf '%s' "${E2E_FAULT_INJECTOR:-}" | tr '[:upper:]' '[:lower:]')"
+case "${E2E_FAULT_INJECTOR_LOWER}" in
+networkfence | none)
+	echo "[3.5/6] Skipping iptables image build/load (E2E_FAULT_INJECTOR is ${E2E_FAULT_INJECTOR_LOWER})."
+	;;
+*)
+	echo "[3.5/6] Preparing iptables image for fault injection..."
+	;;
+esac
 
 # Simple function to load image to cluster
 load_image_to_cluster() {
 	local context="$1"
 	local image="$2"
-	
+
 	echo "  [DEBUG] Attempting to load image '$image' to context '$context'"
-	
+
 	# Test if image is accessible first
-	local test_pod="image-test-$(date +%s)"
+	local test_pod
+	test_pod="image-test-$(date +%s)"
 	echo "  [DEBUG] Testing image accessibility in context '$context'"
 	if kubectl --context="$context" run "$test_pod" --image="$image" --restart=Never --rm --timeout=30s --command -- echo "ok" >/dev/null 2>&1; then
 		echo "Image $image already accessible in $context"
 		return 0
 	fi
 	echo "  [DEBUG] Image not yet accessible in context, attempting to load..."
-	
+
 	# Try to load for kind clusters
 	if command -v kind >/dev/null 2>&1; then
 		local cluster_name="$context"
-		[[ "$context" =~ kind- ]] && cluster_name="$(echo "$context" | sed 's/kind-//')"
-		
+		[[ "$context" =~ kind- ]] && cluster_name="${context#kind-}"
+
 		if kind get clusters 2>/dev/null | grep -q "^${cluster_name}$"; then
 			echo "Loading via kind to cluster: $cluster_name"
 			kind load docker-image "$image" --name="$cluster_name" && return 0
 		fi
 	fi
-	
+
 	# Try to load for k3d clusters
 	if command -v k3d >/dev/null 2>&1; then
 		local cluster_name="$context"
-		[[ "$context" =~ k3d- ]] && cluster_name="$(echo "$context" | sed 's/k3d-//')"
-		
+		[[ "$context" =~ k3d- ]] && cluster_name="${context#k3d-}"
+
 		if k3d cluster list 2>/dev/null | grep -q "$cluster_name"; then
 			echo "Loading via k3d to cluster: $cluster_name"
 			k3d image import "$image" --cluster="$cluster_name" && return 0
 		fi
 	fi
-	
+
 	# Try to load for minikube clusters
 	if command -v minikube >/dev/null 2>&1; then
 		local cluster_name="$context"
 		# Extract cluster name from context (remove minikube- prefix if present)
-		[[ "$context" =~ minikube- ]] && cluster_name="$(echo "$context" | sed 's/minikube-//')"
-		
+		[[ "$context" =~ minikube- ]] && cluster_name="${context#minikube-}"
+
 		echo "  [DEBUG] Checking for minikube profile: '$cluster_name'"
 		if minikube profile list 2>/dev/null | grep -q "^${cluster_name}"; then
 			echo "Loading via minikube to cluster: $cluster_name"
@@ -210,57 +238,58 @@ load_image_to_cluster() {
 			echo "  [DEBUG] Minikube profile '$cluster_name' not found in profile list"
 		fi
 	fi
-	
+
 	echo "Cannot load $image to $context (not kind/k3d/minikube or image not in registry)"
 	return 1
 }
 
 prepare_iptables_image() {
 	local iptables_image="${IPTABLES_IMAGE:-csi-addons/iptables-manager:latest}"
-	
+
 	# Use pre-built iptables image with all tools included
 	# No fallback to alpine - the custom image has everything needed
 	echo "  Using pre-built iptables image: $iptables_image"
-	
+
 	# Only attempt to load image to clusters if DR contexts are set (dual-cluster testing)
 	if [[ -n "${DR1_CONTEXT:-}" && -n "${DR2_CONTEXT:-}" ]]; then
 		echo "  Detected dual-cluster setup (DR1_CONTEXT=${DR1_CONTEXT}, DR2_CONTEXT=${DR2_CONTEXT})"
-		
+
 		# Detect container command
-		if command -v podman > /dev/null 2>&1; then
+		if command -v podman >/dev/null 2>&1; then
 			CONTAINER_CMD="podman"
-		elif command -v docker > /dev/null 2>&1; then
+		elif command -v docker >/dev/null 2>&1; then
 			CONTAINER_CMD="docker"
 		else
 			echo "  WARNING: Neither podman nor docker found, skipping pre-cluster image loading"
 			echo "  (Image should already be available in clusters)"
 		fi
-		
+
 		# Normalize image name - remove localhost/ prefix if present (podman may add it)
 		iptables_image="${iptables_image#localhost/}"
 		echo "  Using normalized image: $iptables_image"
-		
+
 		# Build custom iptables image if needed
 		if [[ "$iptables_image" == "csi-addons/iptables-manager:latest" ]]; then
 			echo "  Checking if custom iptables image needs to be built..."
 			if ! $CONTAINER_CMD images --format "table {{.Repository}}:{{.Tag}}" | grep -E "(^|/)csi-addons/iptables-manager:latest\$" >/dev/null 2>&1; then
 				echo "  Building custom iptables image..."
-				if [[ -f "${REPO_ROOT}/build/Containerfile.iptables" ]]; then
-					if $CONTAINER_CMD build -t "csi-addons/iptables-manager:latest" -f "${REPO_ROOT}/build/Containerfile.iptables" "${REPO_ROOT}/build/" >/dev/null 2>&1; then
+				E2E_IPTABLES_DIR="${REPO_ROOT}/test/e2e/utils"
+				if [[ -f "${E2E_IPTABLES_DIR}/Containerfile.iptables" ]]; then
+					if $CONTAINER_CMD build -t "csi-addons/iptables-manager:latest" -f "${E2E_IPTABLES_DIR}/Containerfile.iptables" "${E2E_IPTABLES_DIR}" >/dev/null 2>&1; then
 						echo "  ✓ Successfully built custom iptables image"
 					else
 						echo "  WARNING: Failed to build custom iptables image, will attempt to use existing"
 					fi
 				else
-					echo "  WARNING: Containerfile.iptables not found, will attempt to use existing image"
+					echo "  WARNING: Containerfile.iptables not found under test/e2e/utils, will attempt to use existing image"
 				fi
 			else
 				echo "  ✓ Custom iptables image already exists locally"
 			fi
 		fi
-		
+
 		echo "  Attempting to load image $iptables_image to DR clusters..."
-		
+
 		# Load to DR1 cluster (non-fatal if fails - image may already be there)
 		echo "    Loading to DR1 cluster ($DR1_CONTEXT)..."
 		if load_image_to_cluster "$DR1_CONTEXT" "$iptables_image"; then
@@ -268,7 +297,7 @@ prepare_iptables_image() {
 		else
 			echo "    ℹ Image not pre-loaded to DR1 (will pull from registry if available)"
 		fi
-		
+
 		# Load to DR2 cluster (non-fatal if fails - image may already be there)
 		echo "    Loading to DR2 cluster ($DR2_CONTEXT)..."
 		if load_image_to_cluster "$DR2_CONTEXT" "$iptables_image"; then
@@ -276,21 +305,27 @@ prepare_iptables_image() {
 		else
 			echo "    ℹ Image not pre-loaded to DR2 (will pull from registry if available)"
 		fi
-		
+
 		echo "  ✓ Ready to use pre-built iptables image in clusters"
 	else
 		echo "  Single-cluster mode: skipping pre-cluster image load"
 	fi
-	
+
 	# Always export the pre-built image (no alpine fallback)
 	export E2E_IPTABLES_IMAGE="$iptables_image"
 }
 
-# Call the image preparation function
-prepare_iptables_image
+# Call the image preparation function when the suite will use iptables fault injection
+case "${E2E_FAULT_INJECTOR_LOWER}" in
+networkfence | none) ;;
+*) prepare_iptables_image ;;
+esac
+echo ""
+echo "[3.75/6] Full environment before go test (sorted; E2E_IPTABLES_IMAGE=${E2E_IPTABLES_IMAGE:-<unset when iptables prep skipped>}):"
+printenv | LC_ALL=C sort
 echo ""
 
-echo "[4/6] Running replication E2E tests (timeout ${REPLICATION_TEST_TIMEOUT}, output tee'd to ${LOG_FILE})..."
+echo "[4/6] Running replication E2E tests (timeout ${REPLICATION_TEST_TIMEOUT}, logging to ${LOG_FILE})..."
 echo "  Use REPLICATION_POLL_TIMEOUT=600 if Replicating=True times out."
 echo "  Use REPLICATION_TEST_TIMEOUT=45m or 60m if suite hits test timeout."
 echo ""
@@ -322,10 +357,11 @@ echo ""
 
 # Run tests with extended timeout (default 30m); cleanup runs on EXIT trap even on panic/timeout.
 set +e
+# shellcheck disable=SC2086  # GINKGO_EXTRA intentionally word-split for multiple arguments
 if command -v stdbuf &>/dev/null; then
-	USE_EXISTING_CLUSTER=true stdbuf -oL go test -v -timeout "${REPLICATION_TEST_TIMEOUT}" "${E2E_PKG}" ${GINKGO_EXTRA} "${GINKGO_FOCUS_FLAG[@]}" "${GINKGO_SKIP_FLAG[@]}" 2>&1 | tee "${LOG_FILE}"
+	USE_EXISTING_CLUSTER=true stdbuf -oL go test -v -timeout "${REPLICATION_TEST_TIMEOUT}" "${E2E_PKG}" ${GINKGO_EXTRA} "${GINKGO_FOCUS_FLAG[@]}" "${GINKGO_SKIP_FLAG[@]}" 2>&1
 else
-	USE_EXISTING_CLUSTER=true go test -v -timeout "${REPLICATION_TEST_TIMEOUT}" "${E2E_PKG}" ${GINKGO_EXTRA} "${GINKGO_FOCUS_FLAG[@]}" "${GINKGO_SKIP_FLAG[@]}" 2>&1 | tee "${LOG_FILE}"
+	USE_EXISTING_CLUSTER=true go test -v -timeout "${REPLICATION_TEST_TIMEOUT}" "${E2E_PKG}" ${GINKGO_EXTRA} "${GINKGO_FOCUS_FLAG[@]}" "${GINKGO_SKIP_FLAG[@]}" 2>&1
 fi
 EXIT_CODE="${PIPESTATUS[0]}"
 set -e

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,328 @@
+#!/bin/bash
+# Pre-commit hook: Align with .github/workflows/lint-extras.yaml super-linter:
+# BASH shellcheck, bash -n, SHELL_SHFMT shfmt, yamllint, MARKDOWN markdownlint,
+# MARKDOWN_PRETTIER prettier. NATURAL_LANGUAGE textlint runs in CI only.
+#
+# Installed via: scripts/setup-hooks.sh
+# To bypass: git commit --no-verify
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Staged shell scripts: *.sh plus repo hook scripts without a .sh suffix (super-linter lints these as BASH).
+staged_shell_files() {
+	git diff --cached --name-only --diff-filter=ACM | grep -E '\.sh$|^scripts/hooks/pre-commit$' || true
+}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "Running pre-commit linting checks..."
+
+FAILED_FILES=()
+PASSED_FILES=()
+TOOLS_AVAILABLE=0
+
+# ============================================================================
+# SHELLCHECK - Check if available first, then process shell files
+# ============================================================================
+if command -v shellcheck &>/dev/null; then
+	TOOLS_AVAILABLE=1
+	SHELL_FILES=$(staged_shell_files)
+
+	if [ -n "$SHELL_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Shellcheck (Shell scripts)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		SHELL_PASSED=0
+		SHELL_FAILED=0
+
+		for file in $SHELL_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				if shellcheck "$REPO_ROOT/$file" 2>/dev/null; then
+					echo -e "${GREEN}Pass${NC}"
+					((++SHELL_PASSED))
+					PASSED_FILES+=("$file")
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++SHELL_FAILED))
+					FAILED_FILES+=("$file")
+					# Show the actual errors
+					shellcheck "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Shellcheck: ${SHELL_PASSED} passed, ${SHELL_FAILED} failed"
+	else
+		echo "No shell scripts to check with shellcheck"
+	fi
+else
+	echo -e "${YELLOW}WARNING: shellcheck is not installed. Skipping shell script linting.${NC}"
+	echo "  Install with: apt-get install shellcheck (or via your package manager)"
+fi
+
+# ============================================================================
+# YAMLLINT - Check if available first, then process YAML files
+# Prefer: yamllint on PATH; else python3 -m yamllint (pip install --user yamllint)
+# ============================================================================
+YAMLLINT_CMD=()
+if command -v yamllint &>/dev/null; then
+	YAMLLINT_CMD=(yamllint)
+	TOOLS_AVAILABLE=1
+elif python3 -c 'import yamllint' 2>/dev/null; then
+	YAMLLINT_CMD=(python3 -m yamllint)
+	TOOLS_AVAILABLE=1
+fi
+
+if [ "${#YAMLLINT_CMD[@]}" -gt 0 ]; then
+	YAML_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(yaml|yml)$' || true)
+
+	if [ -n "$YAML_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Yamllint (YAML files)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		YAML_PASSED=0
+		YAML_FAILED=0
+
+		for file in $YAML_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				if "${YAMLLINT_CMD[@]}" -c "$REPO_ROOT/.yamllint.yaml" "$REPO_ROOT/$file" >/dev/null 2>&1; then
+					echo -e "${GREEN}Pass${NC}"
+					((++YAML_PASSED))
+					PASSED_FILES+=("$file")
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++YAML_FAILED))
+					FAILED_FILES+=("$file")
+					"${YAMLLINT_CMD[@]}" -c "$REPO_ROOT/.yamllint.yaml" "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Yamllint: ${YAML_PASSED} passed, ${YAML_FAILED} failed"
+	else
+		echo "No staged .yaml/.yml files (yamllint skipped for this commit)."
+	fi
+else
+	echo -e "${YELLOW}WARNING: yamllint is not available. Skipping YAML linting.${NC}"
+	echo "  Install: apt-get install yamllint  OR  pip install --user yamllint"
+fi
+
+# ============================================================================
+# BASH_EXEC - Check if shell scripts are executable (bash -n)
+# ============================================================================
+if command -v bash &>/dev/null; then
+	SHELL_FILES=$(staged_shell_files)
+
+	if [ -n "$SHELL_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Bash Syntax Check (bash -n)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		BASH_PASSED=0
+		BASH_FAILED=0
+
+		for file in $SHELL_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				if bash -n "$REPO_ROOT/$file" 2>/dev/null; then
+					echo -e "${GREEN}Pass${NC}"
+					((++BASH_PASSED))
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++BASH_FAILED))
+					FAILED_FILES+=("$file")
+					# Show the actual errors
+					bash -n "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Bash syntax: ${BASH_PASSED} passed, ${BASH_FAILED} failed"
+	fi
+fi
+
+# ============================================================================
+# SHFMT - Check shell script formatting
+# ============================================================================
+if command -v shfmt &>/dev/null; then
+	SHELL_FILES=$(staged_shell_files)
+
+	if [ -n "$SHELL_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Shell Formatting (shfmt)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		SHFMT_PASSED=0
+		SHFMT_FAILED=0
+
+		for file in $SHELL_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				# Check if formatting matches expected
+				if shfmt -i 0 -d "$REPO_ROOT/$file" >/dev/null 2>&1; then
+					echo -e "${GREEN}Pass${NC}"
+					((++SHFMT_PASSED))
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++SHFMT_FAILED))
+					FAILED_FILES+=("$file (formatting)")
+					# Show the diff
+					shfmt -i 0 -d "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Shfmt: ${SHFMT_PASSED} passed, ${SHFMT_FAILED} failed"
+	fi
+else
+	echo -e "${YELLOW}TIP: shfmt not installed. Skipping shell formatting checks.${NC}"
+	echo "     Install with: apt-get install shfmt"
+fi
+
+# ============================================================================
+# MARKDOWNLINT - Check markdown formatting (MARKDOWN in super-linter)
+# Prefer: markdownlint on PATH; else npx markdownlint-cli (npm install -g markdownlint-cli)
+# ============================================================================
+MARKDOWNLINT_CONFIG="$REPO_ROOT/.markdownlint.yaml"
+MDLINT_CMD=()
+if command -v markdownlint &>/dev/null; then
+	MDLINT_CMD=(markdownlint)
+	TOOLS_AVAILABLE=1
+elif command -v npx &>/dev/null; then
+	MDLINT_CMD=(npx --yes markdownlint-cli)
+	TOOLS_AVAILABLE=1
+fi
+if [ -f "$MARKDOWNLINT_CONFIG" ] && [ "${#MDLINT_CMD[@]}" -gt 0 ]; then
+	MDLINT_CMD+=(-c "$MARKDOWNLINT_CONFIG")
+fi
+
+if [ "${#MDLINT_CMD[@]}" -gt 0 ]; then
+	MD_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.md$' || true)
+
+	if [ -n "$MD_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Markdown Linting (markdownlint)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		MD_PASSED=0
+		MD_FAILED=0
+
+		for file in $MD_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				if "${MDLINT_CMD[@]}" "$REPO_ROOT/$file" >/dev/null 2>&1; then
+					echo -e "${GREEN}Pass${NC}"
+					((++MD_PASSED))
+					PASSED_FILES+=("$file")
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++MD_FAILED))
+					FAILED_FILES+=("$file")
+					"${MDLINT_CMD[@]}" "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Markdownlint: ${MD_PASSED} passed, ${MD_FAILED} failed"
+	else
+		echo "No staged .md files (markdownlint skipped for this commit)."
+	fi
+else
+	echo -e "${YELLOW}WARNING: markdownlint is not available. Skipping Markdown rule linting.${NC}"
+	echo "  Install: npm install -g markdownlint-cli  OR  apt install node-markdownlint (provides markdownlint on PATH)"
+fi
+
+# ============================================================================
+# PRETTIER - Markdown formatting (MARKDOWN_PRETTIER in super-linter v7 image)
+# ============================================================================
+if command -v npx &>/dev/null; then
+	TOOLS_AVAILABLE=1
+	MD_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.md$' || true)
+
+	PRETTIER_IGNORE=()
+	if [ -f "$REPO_ROOT/.prettierignore" ]; then
+		PRETTIER_IGNORE=(--ignore-path "$REPO_ROOT/.prettierignore")
+	fi
+
+	if [ -n "$MD_FILES" ]; then
+		echo ""
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+		echo "Prettier (Markdown — same major as super-linter: 3.5.x)"
+		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+		PRETTIER_PASSED=0
+		PRETTIER_FAILED=0
+
+		for file in $MD_FILES; do
+			if [ -f "$REPO_ROOT/$file" ]; then
+				echo -n "  Checking $file... "
+				if npx --yes prettier@3.5.3 --check "${PRETTIER_IGNORE[@]}" "$REPO_ROOT/$file" >/dev/null 2>&1; then
+					echo -e "${GREEN}Pass${NC}"
+					((++PRETTIER_PASSED))
+				else
+					echo -e "${RED}FAILED${NC}"
+					((++PRETTIER_FAILED))
+					FAILED_FILES+=("$file (prettier)")
+					npx --yes prettier@3.5.3 --check "${PRETTIER_IGNORE[@]}" "$REPO_ROOT/$file" || true
+				fi
+			fi
+		done
+
+		echo "Prettier: ${PRETTIER_PASSED} passed, ${PRETTIER_FAILED} failed"
+	else
+		echo "No staged .md files (Prettier skipped for this commit)."
+	fi
+else
+	echo -e "${YELLOW}WARNING: npx not available. Skipping Prettier Markdown checks.${NC}"
+	echo "  Install Node.js (npx) for MARKDOWN_PRETTIER parity with CI."
+fi
+
+# ============================================================================
+# SUMMARY AND EXIT
+# ============================================================================
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Linting Summary:"
+echo "  Passed: ${#PASSED_FILES[@]}"
+echo "  Failed: ${#FAILED_FILES[@]}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$TOOLS_AVAILABLE" -eq 0 ]; then
+	echo -e "${YELLOW}WARNING: No linting tools found on PATH.${NC}"
+	echo "  For CI parity install: shellcheck, yamllint (or: pip install --user yamllint), markdownlint-cli (global or via npx), Node.js (npx) for Prettier."
+	echo "  See docs/development/git-hooks.md"
+	echo "  Allowing commit to proceed without validation."
+	exit 0
+fi
+
+if [ ${#FAILED_FILES[@]} -gt 0 ]; then
+	echo -e "${RED}BLOCKED: Fix linting errors above and try again${NC}"
+	echo ""
+	echo "Files with errors:"
+	for file in "${FAILED_FILES[@]}"; do
+		echo "  - $file"
+	done
+	echo ""
+	echo "You can bypass this check with: git commit --no-verify"
+	echo "But it's recommended to fix the linting issues first."
+	exit 1
+fi
+
+echo -e "${GREEN}All files passed linting!${NC}"
+exit 0

--- a/test/e2e/helpers/connectivity_baseline.go
+++ b/test/e2e/helpers/connectivity_baseline.go
@@ -11,10 +11,63 @@ ConnectivityBaseline and CompareProbeResultsToBaseline are used only by the ipta
 package helpers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 )
+
+// ErrIptablesBaselineSkipEnvironment is returned by EstablishIptablesConnectivityBaselines when
+// probe jobs cannot establish a baseline (e.g. no probe succeeded — ICMP blocked everywhere).
+// Replication E2E specs may translate this with Ginkgo Skip; helpers must not import Ginkgo.
+var ErrIptablesBaselineSkipEnvironment = errors.New("iptables connectivity baseline: environment unsuitable for verify")
+
+// IsIptablesBaselineSkipEnvironmentError reports whether err indicates the cluster cannot run
+// iptables connectivity verification (matches errors from IptablesFaultProvider.EstablishConnectivityBaseline).
+func IsIptablesBaselineSkipEnvironmentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no probe succeeded") ||
+		strings.Contains(msg, "cannot verify fencing")
+}
+
+// EstablishIptablesConnectivityBaselines runs EstablishConnectivityBaseline for each CIDR when
+// injectorType is iptables. For other injectors returns (nil, nil) without calling the provider
+// (NetworkFence and NoOp do not use packet baselines).
+//
+// On failure: wraps with ErrIptablesBaselineSkipEnvironment when IsIptablesBaselineSkipEnvironmentError(err);
+// otherwise returns a fatal error (timeouts, API errors, missing CSI_BASELINE).
+func EstablishIptablesConnectivityBaselines(ctx context.Context, injectorType FaultInjectorType, p PeerFenceProvider, cidrs []string) (map[string]*ConnectivityBaseline, error) {
+	if injectorType != FaultInjectorIptables {
+		return nil, nil
+	}
+	if p == nil {
+		return nil, fmt.Errorf("EstablishIptablesConnectivityBaselines: PeerFenceProvider is required for iptables")
+	}
+	out := make(map[string]*ConnectivityBaseline, len(cidrs))
+	for _, cidr := range cidrs {
+		b, err := p.EstablishConnectivityBaseline(ctx, cidr)
+		if err != nil {
+			if IsIptablesBaselineSkipEnvironmentError(err) {
+				return nil, fmt.Errorf("%w: %v", ErrIptablesBaselineSkipEnvironment, err)
+			}
+			return nil, fmt.Errorf("fence baseline failed (expected reachable path to peer before fence; fix probe/job or networking): %w", err)
+		}
+		out[cidr] = b
+	}
+	return out, nil
+}
+
+// BaselineForCIDR returns the per-CIDR baseline from EstablishIptablesConnectivityBaselines for VerifyConnectivity, or nil.
+func BaselineForCIDR(baselines map[string]*ConnectivityBaseline, cidr string) *ConnectivityBaseline {
+	if baselines == nil {
+		return nil
+	}
+	return baselines[cidr]
+}
 
 // CompareProbeResultsToBaseline returns whether current probes match expected fence state.
 // When expectedFenced is true, probes that were true in baseline must be false after, with

--- a/test/e2e/helpers/connectivity_baseline_test.go
+++ b/test/e2e/helpers/connectivity_baseline_test.go
@@ -8,109 +8,109 @@ you may not use this file except in compliance with the License.
 package helpers
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 )
 
-func TestParseConnectivityBaselineFromLog(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		log     string
-		wantP   bool
-		wantR   bool
-		wantTr  bool
-		wantErr bool
-	}{
-		{
-			name:   "standard line",
-			log:    "foo\nCSI_BASELINE ping=1 ip_route=0 traceroute=1\n",
-			wantP:  true,
-			wantR:  false,
-			wantTr: true,
+func TestIsIptablesBaselineSkipEnvironmentError(t *testing.T) {
+	if !IsIptablesBaselineSkipEnvironmentError(fmt.Errorf("connectivity baseline: no probe succeeded for x")) {
+		t.Fatal("expected skip for no probe succeeded")
+	}
+	if !IsIptablesBaselineSkipEnvironmentError(fmt.Errorf("cannot verify fencing")) {
+		t.Fatal("expected skip for cannot verify fencing")
+	}
+	if IsIptablesBaselineSkipEnvironmentError(fmt.Errorf("kube API timeout")) {
+		t.Fatal("unexpected skip for unrelated error")
+	}
+	if IsIptablesBaselineSkipEnvironmentError(nil) {
+		t.Fatal("nil should not be skip")
+	}
+}
+
+// mockBaselineProvider embeds NoOpFaultProvider and overrides EstablishConnectivityBaseline only.
+type mockBaselineProvider struct {
+	NoOpFaultProvider
+	establish func(ctx context.Context, cidr string) (*ConnectivityBaseline, error)
+}
+
+func (m *mockBaselineProvider) EstablishConnectivityBaseline(ctx context.Context, cidr string) (*ConnectivityBaseline, error) {
+	if m.establish != nil {
+		return m.establish(ctx, cidr)
+	}
+	return m.NoOpFaultProvider.EstablishConnectivityBaseline(ctx, cidr)
+}
+
+func TestEstablishIptablesConnectivityBaselines_nonIptables(t *testing.T) {
+	ctx := context.Background()
+	m, err := EstablishIptablesConnectivityBaselines(ctx, FaultInjectorNetworkFence, nil, []string{"10.0.0.1/32"})
+	if err != nil || m != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil)", m, err)
+	}
+}
+
+func TestEstablishIptablesConnectivityBaselines_iptablesNilProvider(t *testing.T) {
+	ctx := context.Background()
+	_, err := EstablishIptablesConnectivityBaselines(ctx, FaultInjectorIptables, nil, []string{"10.0.0.1/32"})
+	if err == nil {
+		t.Fatal("expected error for nil provider")
+	}
+}
+
+func TestEstablishIptablesConnectivityBaselines_skipEnvironment(t *testing.T) {
+	ctx := context.Background()
+	p := &mockBaselineProvider{
+		establish: func(ctx context.Context, cidr string) (*ConnectivityBaseline, error) {
+			return nil, fmt.Errorf("connectivity baseline: no probe succeeded for %s — cannot verify fencing", cidr)
 		},
-		{
-			name:    "missing line",
-			log:     "no marker here\n",
-			wantErr: true,
+	}
+	_, err := EstablishIptablesConnectivityBaselines(ctx, FaultInjectorIptables, p, []string{"192.0.2.1/32"})
+	if !errors.Is(err, ErrIptablesBaselineSkipEnvironment) {
+		t.Fatalf("got %v want %v", err, ErrIptablesBaselineSkipEnvironment)
+	}
+}
+
+func TestEstablishIptablesConnectivityBaselines_fatal(t *testing.T) {
+	ctx := context.Background()
+	p := &mockBaselineProvider{
+		establish: func(ctx context.Context, cidr string) (*ConnectivityBaseline, error) {
+			return nil, fmt.Errorf("apiserver unavailable")
 		},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			b, err := ParseConnectivityBaselineFromLog("192.0.2.1", tc.log)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if b.TargetIP != "192.0.2.1" {
-				t.Errorf("TargetIP: got %q", b.TargetIP)
-			}
-			if b.PingOK != tc.wantP || b.IPRouteOK != tc.wantR || b.TracerouteOK != tc.wantTr {
-				t.Fatalf("got ping=%v route=%v trace=%v", b.PingOK, b.IPRouteOK, b.TracerouteOK)
-			}
-		})
+	_, err := EstablishIptablesConnectivityBaselines(ctx, FaultInjectorIptables, p, []string{"192.0.2.1/32"})
+	if err == nil || errors.Is(err, ErrIptablesBaselineSkipEnvironment) {
+		t.Fatalf("expected fatal error, got %v", err)
 	}
 }
 
-func TestConnectivityBaseline_AnyProbeSucceeded(t *testing.T) {
-	t.Parallel()
-	if (&ConnectivityBaseline{}).AnyProbeSucceeded() {
-		t.Fatal("empty baseline should be false")
+func TestEstablishIptablesConnectivityBaselines_ok(t *testing.T) {
+	ctx := context.Background()
+	want := &ConnectivityBaseline{TargetIP: "192.0.2.1", PingOK: true}
+	p := &mockBaselineProvider{
+		establish: func(ctx context.Context, cidr string) (*ConnectivityBaseline, error) {
+			return want, nil
+		},
 	}
-	b := &ConnectivityBaseline{PingOK: true}
-	if !b.AnyProbeSucceeded() {
-		t.Fatal("expected true")
+	m, err := EstablishIptablesConnectivityBaselines(ctx, FaultInjectorIptables, p, []string{"192.0.2.1/32"})
+	if err != nil {
+		t.Fatal(err)
 	}
-}
-
-func TestCompareProbeResultsToBaseline_Fenced(t *testing.T) {
-	t.Parallel()
-	before := &ConnectivityBaseline{PingOK: true, IPRouteOK: true, TracerouteOK: false}
-	afterLoss := &ConnectivityBaseline{PingOK: false, IPRouteOK: false, TracerouteOK: false}
-	if !CompareProbeResultsToBaseline(before, afterLoss, true) {
-		t.Fatal("expected fenced match when ping/route lost")
-	}
-	afterStillPing := &ConnectivityBaseline{PingOK: true, IPRouteOK: false, TracerouteOK: false}
-	if CompareProbeResultsToBaseline(before, afterStillPing, true) {
-		t.Fatal("expected failure when ping still ok")
+	if m == nil || m["192.0.2.1/32"] != want {
+		t.Fatalf("map: %v", m)
 	}
 }
 
-func TestCompareProbeResultsToBaseline_Fenced_pingLossEnoughWhenTracerouteNoisy(t *testing.T) {
-	t.Parallel()
-	// Mirrors e2e: after fence, ping drops but ip route + traceroute probes can stay "true"
-	// (local route lookup; traceroute matches any hop line).
-	before := &ConnectivityBaseline{PingOK: true, IPRouteOK: true, TracerouteOK: true}
-	after := &ConnectivityBaseline{PingOK: false, IPRouteOK: true, TracerouteOK: true}
-	if !CompareProbeResultsToBaseline(before, after, true) {
-		t.Fatal("expected fenced match when baseline ping worked and ping fails after fence")
+func TestBaselineForCIDR(t *testing.T) {
+	if BaselineForCIDR(nil, "x") != nil {
+		t.Fatal("nil map")
 	}
-}
-
-func TestCompareProbeResultsToBaseline_Reachable(t *testing.T) {
-	t.Parallel()
-	before := &ConnectivityBaseline{PingOK: true, IPRouteOK: false, TracerouteOK: true}
-	after := &ConnectivityBaseline{PingOK: true, IPRouteOK: false, TracerouteOK: true}
-	if !CompareProbeResultsToBaseline(before, after, false) {
-		t.Fatal("expected reachable match")
+	b := &ConnectivityBaseline{}
+	m := map[string]*ConnectivityBaseline{"10.0.0.1/32": b}
+	if BaselineForCIDR(m, "10.0.0.1/32") != b {
+		t.Fatal("lookup")
 	}
-	afterBad := &ConnectivityBaseline{PingOK: false, IPRouteOK: false, TracerouteOK: true}
-	if CompareProbeResultsToBaseline(before, afterBad, false) {
-		t.Fatal("expected failure when ping lost after unfence")
-	}
-}
-
-func TestCompareProbeResultsToBaseline_Nil(t *testing.T) {
-	t.Parallel()
-	if CompareProbeResultsToBaseline(nil, &ConnectivityBaseline{}, true) {
-		t.Fatal("nil before should be false")
-	}
-	if CompareProbeResultsToBaseline(&ConnectivityBaseline{}, nil, true) {
-		t.Fatal("nil after should be false")
+	if BaselineForCIDR(m, "other") != nil {
+		t.Fatal("missing key")
 	}
 }

--- a/test/e2e/helpers/fault_injection.go
+++ b/test/e2e/helpers/fault_injection.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,8 +45,9 @@ const (
 )
 
 // PeerFenceProvider defines the interface for network fault injection mechanisms.
-// This interface abstracts different backends (NetworkFence CRDs, iptables, etc.)
-// to provide a unified API for peer network isolation in E2E tests.
+// Backends differ: iptables uses host-level packet filtering and optional Jobs to probe reachability;
+// NetworkFence is implemented at the storage / CSI layer—whether the peer is “reachable” for DR flows
+// is reflected on VolumeReplication and related CRs, not via ICMP probes in the workload namespace.
 type PeerFenceProvider interface {
 	// FenceIP blocks network connectivity to the specified CIDR or IP address.
 	// This simulates network partition scenarios for disaster recovery testing.
@@ -69,18 +71,19 @@ type PeerFenceProvider interface {
 	// Returns error if unfencing operation fails.
 	UnfenceIP(ctx context.Context, targetCIDR string, params map[string]string) error
 
-	// VerifyConnectivity checks if network connectivity to the target is available.
-	// This verifies the current fence state and validates fence/unfence operations.
-	//
-	// Parameters:
-	//   - ctx: Context for the operation with timeout/cancellation
-	//   - targetCIDR: IP address or CIDR block to test connectivity
-	//   - expectedFenced: true if the target should be fenced (unreachable)
-	//
-	// Returns:
-	//   - bool: true if connectivity matches expected state
-	//   - error: error during connectivity verification (nil if successful)
-	VerifyConnectivity(ctx context.Context, targetCIDR string, expectedFenced bool) (bool, error)
+	// EstablishConnectivityBaseline is for iptables fault injection only: it runs short-lived Jobs
+	// (ping, ip route get, traceroute) and records which probes reached the target before OUTPUT REJECT.
+	// NetworkFence does not use packet probes—returns (nil, nil). NoOp returns (nil, nil).
+	// For NetworkFence scenarios, assert peer state via VolumeReplication conditions instead.
+	EstablishConnectivityBaseline(ctx context.Context, targetCIDR string) (*ConnectivityBaseline, error)
+
+	// VerifyConnectivity meaning depends on the provider:
+	//   - Iptables: optional packet probes vs baseline (see ConnectivityBaseline); if baseline is nil,
+	//     “reachable” means any probe succeeded (ICMP may be blocked without a fence).
+	//   - NetworkFence: compares expected fence state to the NetworkFence CR (and active fence tracking);
+	//     baseline is ignored—connectivity from the replication layer’s perspective belongs in VR tests.
+	//   - NoOp: always matches expectations.
+	VerifyConnectivity(ctx context.Context, targetCIDR string, expectedFenced bool, baseline *ConnectivityBaseline) (bool, error)
 
 	// IsSupported returns true if this fault injection mechanism is available in the cluster.
 	// This allows tests to skip gracefully when the required capabilities are not available.
@@ -105,13 +108,17 @@ type FaultInjectionConfig struct {
 	// Namespace for provider resources (DaemonSets, etc.)
 	Namespace string
 
+	// RESTConfig is the cluster REST client config. Required for iptables fence/unfence: commands run only
+	// via exec into the iptables DaemonSet pods (same cluster as Client).
+	RESTConfig *rest.Config
+
 	// ProviderParams contains provider-specific configuration
 	ProviderParams map[string]string
 }
 
 // NewFaultInjectionProvider creates a new fault injection provider based on configuration.
 // The provider type is determined by the E2E_FAULT_INJECTOR environment variable,
-// with fallback to NetworkFence for backward compatibility.
+// with fallback to iptables when unset (design default).
 //
 // Environment variable values:
 //   - "networkfence": Uses NetworkFence CRDs (requires CSI-Addons controller)
@@ -137,7 +144,7 @@ func NewFaultInjectionProvider(config FaultInjectionConfig) (PeerFenceProvider, 
 		case string(FaultInjectorNone):
 			providerType = FaultInjectorNone
 		case "":
-			// Default to iptables for better cluster compatibility
+			// Design default: iptables-based fault injection
 			providerType = FaultInjectorIptables
 		default:
 			return nil, fmt.Errorf("unsupported fault injector type: %s (supported: networkfence, iptables, none)", envType)
@@ -169,7 +176,23 @@ func GetFaultInjectorTypeFromEnv() FaultInjectorType {
 	case string(FaultInjectorNone):
 		return FaultInjectorNone
 	default:
-		return FaultInjectorIptables // Default to iptables for better compatibility
+		return FaultInjectorIptables
+	}
+}
+
+// SweepIptablesResidualAfterUnfence runs the staged REJECT sweep on all iptables manager pods when the
+// fault injector is iptables. Call after UnfenceIP when replication or resync must proceed: per-CIDR
+// UnfenceIP can leave rules on some nodes until this sweep runs. Best-effort: logs a warning on error.
+func SweepIptablesResidualAfterUnfence(ctx context.Context, injector FaultInjectorType, p PeerFenceProvider) {
+	if injector != FaultInjectorIptables || p == nil {
+		return
+	}
+	ipt, ok := p.(*IptablesFaultProvider)
+	if !ok {
+		return
+	}
+	if err := ipt.SweepResidualFenceRules(ctx); err != nil {
+		Logf("[WARNING]", "iptables post-unfence residual sweep: %v", err)
 	}
 }
 
@@ -195,7 +218,13 @@ func (p *NoOpFaultProvider) UnfenceIP(ctx context.Context, targetCIDR string, pa
 	return nil
 }
 
-func (p *NoOpFaultProvider) VerifyConnectivity(ctx context.Context, targetCIDR string, expectedFenced bool) (bool, error) {
+func (p *NoOpFaultProvider) EstablishConnectivityBaseline(ctx context.Context, targetCIDR string) (*ConnectivityBaseline, error) {
+	_ = ctx
+	_ = targetCIDR
+	return nil, nil
+}
+
+func (p *NoOpFaultProvider) VerifyConnectivity(ctx context.Context, targetCIDR string, expectedFenced bool, baseline *ConnectivityBaseline) (bool, error) {
 	// No-op: always report connectivity as expected (no actual fencing occurred)
 	return true, nil
 }

--- a/test/e2e/helpers/iptables_provider.go
+++ b/test/e2e/helpers/iptables_provider.go
@@ -194,6 +194,8 @@ func (p *IptablesFaultProvider) FenceIP(ctx context.Context, targetCIDR string, 
 	if err := p.syncFenceStateConfigMap(ctx); err != nil {
 		Logf("[WARNING]", "post-fence sync fence state ConfigMap (may fail if API path is blocked): %v", err)
 	}
+	// This event records success of the iptables fencing step (executeIptablesCommand for "fence"), not the
+	// post-fence ConfigMap sync. ConfigMap update may fail; that case is handled by the Logf immediately above.
 	p.emitIptablesFenceEvent(ctx, EventReasonIptablesFenceApplied, fmt.Sprintf(
 		"Applied OUTPUT+FORWARD REJECT to %s (workload namespace %q). State: kubectl -n %s get configmap %s -o yaml",
 		targetCIDR, p.config.Namespace, p.dsNamespace, IptablesFenceStateConfigMapName))
@@ -207,6 +209,14 @@ func (p *IptablesFaultProvider) FenceIP(ctx context.Context, targetCIDR string, 
 	return nil
 }
 
+// UnfenceIP removes OUTPUT/FORWARD REJECT rules for targetCIDR from iptables manager DaemonSet pods.
+//
+// Error handling: if executeIptablesCommand fails (e.g. remote exec error on one node after succeeding on others),
+// targetCIDR remains in activeFenceRules so callers can retry. A best-effort staged REJECT sweep runs to strip
+// CSI-Addons icmp-host-unreachable rules on all manager pods and reduce leftover partition state. Tests should
+// still register DeferCleanup with PeerFenceProvider.Cleanup (full unfence of tracked CIDRs, staged sweep,
+// ConfigMap teardown, optional DS delete when owned)—not only a loop of UnfenceIP by CIDR—so teardown matches
+// L1-E-003 and survives partial failures.
 func (p *IptablesFaultProvider) UnfenceIP(ctx context.Context, targetCIDR string, params map[string]string) error {
 	clusterContext := p.getClusterContext()
 	Logf("[INFO]", "[%s] UnfenceIP: removing iptables block for CIDR %s (DaemonSet %s)", clusterContext, targetCIDR, IptablesDaemonSetName)
@@ -221,11 +231,17 @@ func (p *IptablesFaultProvider) UnfenceIP(ctx context.Context, targetCIDR string
 	Logf("[DEBUG]", "[%s] Removing iptables fence rule for CIDR %s from DaemonSet pods", clusterContext, targetCIDR)
 	if err := p.executeIptablesCommand(ctx, targetCIDR, "unfence"); err != nil {
 		Logf("[ERROR]", "[%s] Failed to add iptables unfence rule for IP %s to DaemonSet %s: %v", clusterContext, targetCIDR, IptablesDaemonSetName, err)
+		if sweepErr := p.removeCSIAddonsStagedRejectRulesOnAllManagerPods(ctx); sweepErr != nil {
+			Logf("[WARNING]", "best-effort staged REJECT sweep after unfence exec error: %v", sweepErr)
+		} else {
+			Logf("[INFO]", "best-effort staged REJECT sweep ran after unfence exec error (may have cleared rules on remaining nodes)")
+		}
 		return fmt.Errorf("[%s] failed to add iptables unfence rule to %s: %w", clusterContext, IptablesDaemonSetName, err)
 	}
 
 	p.removeFromActiveRules(targetCIDR)
 
+	// Event reflects iptables unfence success above, not ConfigMap sync (may warn below).
 	p.emitIptablesFenceEvent(ctx, EventReasonIptablesFenceRemoved, fmt.Sprintf(
 		"Removed OUTPUT+FORWARD REJECT for %s (workload namespace %q)", targetCIDR, p.config.Namespace))
 	if err := p.syncFenceStateConfigMap(ctx); err != nil {
@@ -397,6 +413,14 @@ func (p *IptablesFaultProvider) fetchProbeJobLogs(ctx context.Context, namespace
 		return "", fmt.Errorf("get pod logs %s: %w", podName, err)
 	}
 	return string(raw), nil
+}
+
+// SweepResidualFenceRules runs the same best-effort cleanup as the staged REJECT sweep at the end of
+// Cleanup (removeCSIAddonsStagedRejectRulesOnAllManagerPods). Call after UnfenceIP when replication
+// or resync must proceed on the data path: per-pod iptables -D can miss rules on some nodes, or
+// nft/legacy quirks can leave matching REJECT lines until this sweep runs.
+func (p *IptablesFaultProvider) SweepResidualFenceRules(ctx context.Context) error {
+	return p.removeCSIAddonsStagedRejectRulesOnAllManagerPods(ctx)
 }
 
 func (p *IptablesFaultProvider) Cleanup(ctx context.Context) error {
@@ -759,7 +783,7 @@ func (p *IptablesFaultProvider) tryAdoptExistingDaemonSet(ctx context.Context) (
 	return false, nil
 }
 
-// deployDaemonSet creates and deploys the iptables management DaemonSet and ConfigMap
+// deployDaemonSet creates the iptables DaemonSet only (no rules ConfigMap; see IptablesFenceStateConfigMapName for runtime CM).
 func (p *IptablesFaultProvider) deployDaemonSet(ctx context.Context) error {
 	clusterContext := p.getClusterContext()
 
@@ -864,17 +888,9 @@ func (p *IptablesFaultProvider) createIptablesDaemonSet() *appsv1.DaemonSet {
 
 	const templatePath = "templates/iptables-daemonset.yaml"
 	daemonSet := &appsv1.DaemonSet{}
-	Logf("[DEBUG]", "About to render DaemonSet template: %s", templatePath)
 	if err := p.renderTemplate(templatePath, data, daemonSet); err != nil {
 		Logf("[ERROR]", "Failed to render DaemonSet template: %v", err)
 		return daemonSet // Return empty DaemonSet instead of panicking
-	}
-	Logf("[DEBUG]", "Successfully rendered DaemonSet template")
-
-	// Debug: Log the rendered DaemonSet volumes
-	Logf("[DEBUG]", "DaemonSet volumes count: %d", len(daemonSet.Spec.Template.Spec.Volumes))
-	for i, vol := range daemonSet.Spec.Template.Spec.Volumes {
-		Logf("[DEBUG]", "Volume %d: %s", i, vol.Name)
 	}
 
 	return daemonSet
@@ -899,9 +915,6 @@ func (p *IptablesFaultProvider) renderTemplate(templatePath string, data Templat
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
 	}
-
-	// Debug: Log the rendered YAML content
-	Logf("[DEBUG]", "Rendered template content:\n%s", buf.String())
 
 	// Decode YAML into the object
 	if err := yaml.Unmarshal(buf.Bytes(), obj); err != nil {
@@ -1422,7 +1435,8 @@ func (p *IptablesFaultProvider) cleanupAllFenceRules(ctx context.Context, ds *ap
 	return nil
 }
 
-// createCleanupJob runs cleanup only by exec into the DaemonSet pod (same as fence/unfence).
+// createCleanupJob runs cleanup by remote exec into the DaemonSet pod (same transport as fence/unfence).
+// Despite the name, this does not create a batch/v1 Job.
 func (p *IptablesFaultProvider) createCleanupJob(ctx context.Context, targetPod *corev1.Pod, command string) error {
 	if p.config.RESTConfig == nil {
 		Logf("[WARNING]", "iptables emergency cleanup skipped for pod %s/%s: RESTConfig is nil", targetPod.Namespace, targetPod.Name)

--- a/test/e2e/helpers/templates/iptables-configmap.yaml
+++ b/test/e2e/helpers/templates/iptables-configmap.yaml
@@ -1,8 +1,10 @@
+# yamllint disable rule:braces,rule:comments
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: csi-addons-iptables-manager-rules
-  namespace: {{ .Namespace }}
+  namespace: {{.Namespace}}
   labels:
     app: csi-addons-iptables-manager
     csi-addons.io/component: fault-injection

--- a/test/e2e/helpers/templates/iptables-daemonset.yaml
+++ b/test/e2e/helpers/templates/iptables-daemonset.yaml
@@ -1,8 +1,11 @@
+# yamllint disable rule:braces,rule:comments,rule:trailing-spaces
+# This file contains Go template syntax that yamllint cannot parse
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: csi-addons-iptables-manager
-  namespace: {{ .Namespace }}
+  namespace: {{.Namespace}}
   labels:
     app: csi-addons-iptables-manager
     csi-addons.io/component: fault-injection
@@ -20,33 +23,41 @@ spec:
       {{- if .NodeSelector }}
       nodeSelector:
         {{- range $key, $value := .NodeSelector }}
-        {{ $key }}: {{ $value }}
+        {{$key}}: {{$value}}  # yamllint disable-line rule:syntax
         {{- end }}
       {{- end }}
       securityContext:
         runAsUser: 0
       containers:
       - name: iptables-manager
-        image: {{ .Image }}
+        image: {{.Image}}
         imagePullPolicy: Never
         command:
         - sh
         - -c
         - |
           echo 'CSI-Addons Iptables Manager starting...';
-          echo 'Iptables version:'; iptables --version &&
-          echo 'Available tools:'; which iptables ping nc nslookup &&
+          # Test iptables detection using pre-built script
+          IPT_CMD=$(detect-iptables)
+          if [ -z "$IPT_CMD" ]; then
+            echo "ERROR: No working iptables command found"
+            exit 1
+          fi
+
+          echo "Detected iptables command: $IPT_CMD"
+          echo "Iptables version:"; "$IPT_CMD" --version
+          echo 'Available tools:'; which "$IPT_CMD" ping nc nslookup
+          echo 'Available fence commands:'; ls -la /usr/local/bin/*fence* /usr/local/bin/detect-iptables
           echo 'Creating readiness marker...';
           touch /tmp/iptables-ready &&
-          echo 'Starting iptables rules monitoring loop...';
+          echo 'Iptables manager ready for fence operations via kubectl exec';
+          # Keep container running for exec commands
           while true; do
-            if [ -f /rules/apply.sh ]; then
-              echo '[$(date)] Executing /rules/apply.sh';
-              chmod +x /rules/apply.sh && /rules/apply.sh 2>&1 | tee -a /var/log/iptables.log;
-            else
-              echo '[$(date)] No rules file found, waiting...';
-            fi;
-            sleep 10;
+            sleep 30
+            # Periodically check iptables health
+            if ! "$IPT_CMD" --version >/dev/null 2>&1; then
+              echo "[$(date)] WARNING: iptables command failed health check"
+            fi
           done
         securityContext:
           privileged: true
@@ -66,7 +77,7 @@ spec:
             command:
             - sh
             - -c
-            - test -f /tmp/iptables-ready && iptables --version
+            - test -f /tmp/iptables-ready
           initialDelaySeconds: 2
           periodSeconds: 5
           timeoutSeconds: 3
@@ -84,18 +95,11 @@ spec:
           successThreshold: 1
           failureThreshold: 10
         volumeMounts:
-        - name: iptables-rules
-          mountPath: /rules
-          readOnly: true
         - name: tmp-dir
           mountPath: /tmp
       tolerations:
       - operator: Exists
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: iptables-rules
-        configMap:
-          name: csi-addons-iptables-manager-rules
-          defaultMode: 0755
       - name: tmp-dir
         emptyDir: {}

--- a/test/e2e/replication/demote_volumereplication_test.go
+++ b/test/e2e/replication/demote_volumereplication_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
 
 var _ = Describe("DemoteVolumeReplication", func() {
@@ -90,13 +90,8 @@ var _ = Describe("DemoteVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
-
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR1, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR1, nfc)
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -382,9 +377,19 @@ var _ = Describe("DemoteVolumeReplication", func() {
 			By("Starting L1-DEM-003: Demote primary to secondary with peer unreachable (force=false)")
 			SkipIfNotFullDR("L1-DEM-003", "requires two clusters (DR1_CONTEXT and DR2_CONTEXT)")
 
-			By("Checking that the driver supports NetworkFence")
-			if !IsNetworkFenceSupportAvailable() {
-				Skip("L1-DEM-003 requires NetworkFence and NetworkFenceClass CRDs to be installed and the CSI driver to advertise network_fence.NETWORK_FENCE in CSIAddonsNode status.capabilities.")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			if injector == helpers.FaultInjectorNone {
+				Skip("L1-DEM-003 requires fault injection (E2E_FAULT_INJECTOR=iptables|networkfence)")
+			}
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				if !IsNetworkFenceSupportAvailable() {
+					Skip("L1-DEM-003 (networkfence) requires NetworkFence CRDs and CSI driver network_fence capability in CSIAddonsNode.")
+				}
+			case helpers.FaultInjectorIptables:
+				if !helpers.HasPrivilegedDaemonSetSupport(ctx, GetK8sClientForCluster(ClusterDR1)) {
+					Skip("L1-DEM-003 (iptables) requires privileged DaemonSet support on DR1 for iptables fault injection.")
+				}
 			}
 
 			cDR1 := GetK8sClientForCluster(ClusterDR1)
@@ -422,13 +427,16 @@ var _ = Describe("DemoteVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
+			var faultProvider helpers.PeerFenceProvider
 
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR1, nf, vrDR1)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR1, nfc)
+				if faultProvider != nil {
+					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
+						Logf("[WARNING]", "L1-DEM-003: fault injection log collection: %v", err)
+					}
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -440,25 +448,48 @@ var _ = Describe("DemoteVolumeReplication", func() {
 				DeleteNamespace(cleanupCtx, cDR2, ns2)
 			})
 
-			By("[DR1] Creating NetworkFenceClass to fence peer cluster")
-			nfcName := "nfc-dem-003-" + nsName
-			nfc = CreateNetworkFenceClass(ctx, cDR1, nfcName, env.Provisioner, secretName, secretNs)
-
-			By("[DR1] Getting fence CIDRs for peer cluster nodes")
-			cidrs := GetFenceCIDRsWithPeerNodeClient(ctx, cDR1, cDR2, env.Provisioner, nfcName)
-			if len(cidrs) == 0 {
-				Skip("L1-DEM-003 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or ensure peer cluster (DR2) has node InternalIPs for NetworkFence fallback")
+			var err error
+			faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     cDR1,
+				RESTConfig: GetRESTConfig(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner":     env.Provisioner,
+					"image":           helpers.DefaultIptablesImageWithRegistry,
+					"cluster_context": "DR1",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-DEM-003 (%s): fault injection not supported on this cluster", injector))
 			}
 
-			nfName := "nf-dem-003-" + nsName
-			By("[DR1] Creating NetworkFence (Fenced) to block peer cluster access")
-			nf = CreateNetworkFence(ctx, cDR1, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-			By("[DR1] Waiting for NetworkFence to report Succeeded")
-			WaitForNetworkFenceResult(ctx, cDR1, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			var cidrs []string
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				By("[DR1] Getting fence CIDRs for NetworkFence (FENCE_CIDRS, CSI status, or peer node IPs)")
+				cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR1, cDR2, env.Provisioner, "")
+			case helpers.FaultInjectorIptables:
+				By("[DR1] Getting fence CIDRs for iptables (peer backends on DR2)")
+				cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR1, cDR2)
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-DEM-003 could not get CIDRs: set FENCE_CIDRS or service discovery env vars; see replication-e2e-suite.md")
+			}
+
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			By(fmt.Sprintf("[DR1] Fencing peer CIDRs via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
+				time.Sleep(5 * time.Second)
+			}
 
 			By("[DR1] Attempting to demote primary to secondary while peer is fenced (force=false; should fail)")
 			vrDR1.Spec.ReplicationState = replicationv1alpha1.Secondary
-			err := cDR1.Update(ctx, vrDR1)
+			err = cDR1.Update(ctx, vrDR1)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("[DR1] Waiting for VR to report error (FailedToDemote or peer unreachable)")
@@ -472,11 +503,10 @@ var _ = Describe("DemoteVolumeReplication", func() {
 			Expect(vrDR1.Status.State).NotTo(Equal(replicationv1alpha1.SecondaryState),
 				"L1-DEM-003: VR state should not change to Secondary when peer is unreachable with force=false")
 
-			By("[DR1] Unfencing by setting NetworkFence state to Unfenced")
-			UnfenceNetworkFence(ctx, cDR1, nf)
-
-			By("[DR1] Waiting for NetworkFence unfence operation to complete successfully")
-			WaitForNetworkFenceResult(ctx, cDR1, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			By("[DR1] Unfencing peer (PeerFenceProvider)")
+			for _, cidr := range cidrs {
+				Expect(faultProvider.UnfenceIP(ctx, cidr, nil)).To(Succeed(), "UnfenceIP %s", cidr)
+			}
 
 			By("[DR1] Waiting for RBD mirror and cluster to recover VR health (Degraded=False)")
 			Eventually(func() bool {
@@ -527,9 +557,19 @@ var _ = Describe("DemoteVolumeReplication", func() {
 			By("Starting L1-DEM-004: Demote primary to secondary with peer unreachable (force=true)")
 			SkipIfNotFullDR("L1-DEM-004", "requires two clusters (DR1_CONTEXT and DR2_CONTEXT)")
 
-			By("Checking that the driver supports NetworkFence")
-			if !IsNetworkFenceSupportAvailable() {
-				Skip("L1-DEM-004 requires NetworkFence and NetworkFenceClass CRDs to be installed and the CSI driver to advertise network_fence.NETWORK_FENCE in CSIAddonsNode status.capabilities.")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			if injector == helpers.FaultInjectorNone {
+				Skip("L1-DEM-004 requires fault injection (E2E_FAULT_INJECTOR=iptables|networkfence)")
+			}
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				if !IsNetworkFenceSupportAvailable() {
+					Skip("L1-DEM-004 (networkfence) requires NetworkFence CRDs and CSI driver network_fence capability in CSIAddonsNode.")
+				}
+			case helpers.FaultInjectorIptables:
+				if !helpers.HasPrivilegedDaemonSetSupport(ctx, GetK8sClientForCluster(ClusterDR1)) {
+					Skip("L1-DEM-004 (iptables) requires privileged DaemonSet support on DR1 for iptables fault injection.")
+				}
 			}
 
 			cDR1 := GetK8sClientForCluster(ClusterDR1)
@@ -567,13 +607,16 @@ var _ = Describe("DemoteVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
+			var faultProvider helpers.PeerFenceProvider
 
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR1, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR1, nfc)
+				if faultProvider != nil {
+					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
+						Logf("[WARNING]", "L1-DEM-004: fault injection log collection: %v", err)
+					}
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -585,25 +628,48 @@ var _ = Describe("DemoteVolumeReplication", func() {
 				DeleteNamespace(cleanupCtx, cDR2, ns2)
 			})
 
-			By("[DR1] Creating NetworkFenceClass to fence peer cluster")
-			nfcName := "nfc-dem-004-" + nsName
-			nfc = CreateNetworkFenceClass(ctx, cDR1, nfcName, env.Provisioner, secretName, secretNs)
-
-			By("[DR1] Getting fence CIDRs for peer cluster nodes")
-			cidrs := GetFenceCIDRsWithPeerNodeClient(ctx, cDR1, cDR2, env.Provisioner, nfcName)
-			if len(cidrs) == 0 {
-				Skip("L1-DEM-004 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or ensure peer cluster (DR2) has node InternalIPs for NetworkFence fallback")
+			var err error
+			faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     cDR1,
+				RESTConfig: GetRESTConfig(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner":     env.Provisioner,
+					"image":           helpers.DefaultIptablesImageWithRegistry,
+					"cluster_context": "DR1",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-DEM-004 (%s): fault injection not supported on this cluster", injector))
 			}
 
-			nfName := "nf-dem-004-" + nsName
-			By("[DR1] Creating NetworkFence (Fenced) to block peer cluster access")
-			nf = CreateNetworkFence(ctx, cDR1, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-			By("[DR1] Waiting for NetworkFence to report Succeeded")
-			WaitForNetworkFenceResult(ctx, cDR1, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			var cidrs []string
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				By("[DR1] Getting fence CIDRs for NetworkFence")
+				cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR1, cDR2, env.Provisioner, "")
+			case helpers.FaultInjectorIptables:
+				By("[DR1] Getting fence CIDRs for iptables (peer backends on DR2)")
+				cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR1, cDR2)
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-DEM-004 could not get CIDRs: set FENCE_CIDRS or service discovery env vars; see replication-e2e-suite.md")
+			}
+
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			By(fmt.Sprintf("[DR1] Fencing peer CIDRs via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
+				time.Sleep(5 * time.Second)
+			}
 
 			By("[DR1] Attempting to demote primary to secondary while peer is fenced (force=true; should succeed)")
 			vrDR1.Spec.ReplicationState = replicationv1alpha1.Secondary
-			err := cDR1.Update(ctx, vrDR1)
+			err = cDR1.Update(ctx, vrDR1)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("[DR1] Waiting for VR to report success (Replicating or Completed with Demoted reason)")
@@ -628,11 +694,10 @@ var _ = Describe("DemoteVolumeReplication", func() {
 			Expect(hasReplicationSuccessCondition(vrDR1)).To(BeTrue(),
 				"L1-DEM-004: VR must have Replicating or Completed condition after force demote")
 
-			By("[DR1] Unfencing by setting NetworkFence state to Unfenced")
-			UnfenceNetworkFence(ctx, cDR1, nf)
-
-			By("[DR1] Waiting for NetworkFence unfence operation to complete successfully")
-			WaitForNetworkFenceResult(ctx, cDR1, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			By("[DR1] Unfencing peer (PeerFenceProvider)")
+			for _, cidr := range cidrs {
+				Expect(faultProvider.UnfenceIP(ctx, cidr, nil)).To(Succeed(), "UnfenceIP %s", cidr)
+			}
 
 			By("[DR1] Waiting for RBD mirror and cluster to recover VR health (Degraded=False)")
 			Eventually(func() bool {
@@ -664,8 +729,6 @@ var _ = Describe("DemoteVolumeReplication", func() {
 			By("Assertions: L1-DEM-004 — VR remains stable after unfence")
 			Expect(vrDR1.Status.State).To(Or(Equal(replicationv1alpha1.SecondaryState), Equal(replicationv1alpha1.UnknownState)),
 				"L1-DEM-004: VR state should remain Secondary or Unknown after unfence, got %q", vrDR1.Status.State)
-
-			DeleteNetworkFenceWithCleanup(ctx, cDR1, nf)
 		})
 	})
 

--- a/test/e2e/replication/disable_volumereplication_test.go
+++ b/test/e2e/replication/disable_volumereplication_test.go
@@ -19,6 +19,7 @@ package replication
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
 
 var _ = Describe("DisableVolumeReplication", func() {
@@ -228,11 +229,22 @@ var _ = Describe("DisableVolumeReplication", func() {
 
 	Describe("L1-DIS-005: Disable with peer unreachable (force=false)", func() {
 		It("L1-DIS-005: disable replication on primary when peer unreachable (force=false), expect graceful failure", func() {
-			By("L1-DIS-005: NetworkFence blocks peer; create VR, attempt disable (should fail gracefully)")
+			By("L1-DIS-005: fault injection blocks peer; create VR, attempt disable (should fail gracefully)")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			if injector == helpers.FaultInjectorNone {
+				Skip("L1-DIS-005 requires fault injection (set E2E_FAULT_INJECTOR to iptables or networkfence)")
+			}
+
 			c := GetK8sClient()
-			By("Checking that the driver supports NetworkFence (cached at suite initialization)")
-			if !IsNetworkFenceSupportAvailable() {
-				Skip("L1-DIS-005 requires NetworkFence support. Install NetworkFence CRDs and ensure driver advertises network_fence.NETWORK_FENCE.")
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				if !IsNetworkFenceSupportAvailable() {
+					Skip("L1-DIS-005 (networkfence) requires NetworkFence CRDs and driver network_fence capability.")
+				}
+			case helpers.FaultInjectorIptables:
+				if !helpers.HasPrivilegedDaemonSetSupport(ctx, c) {
+					Skip("L1-DIS-005 (iptables) requires privileged DaemonSet support for iptables fault injection.")
+				}
 			}
 
 			nsName := UniqueNamespace()
@@ -249,21 +261,55 @@ var _ = Describe("DisableVolumeReplication", func() {
 			By("Creating VolumeReplicationClass (snapshot)")
 			vrc := CreateVolumeReplicationClass(ctx, c, vrcName, env.Provisioner, secretName, secretNs, MirroringModeSnapshot)
 
-			nfcName := "nfc-dis-fence-" + nsName
-			By("Creating NetworkFenceClass")
-			nfc := CreateNetworkFenceClass(ctx, c, nfcName, env.Provisioner, secretName, secretNs)
-
-			By("Getting fence CIDRs")
-			cidrs := GetFenceCIDRs(ctx, c, env.Provisioner, nfcName)
-			if len(cidrs) == 0 {
-				Skip("L1-DIS-005 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or ensure nodes have InternalIPs for NetworkFence fallback")
+			faultProvider, err := helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     c,
+				RESTConfig: GetRESTConfig(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner": env.Provisioner,
+					"image":       helpers.DefaultIptablesImageWithRegistry,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-DIS-005 (%s): fault injection provider not supported on this cluster", injector))
 			}
 
-			nfName := "nf-dis-fence-" + nsName
-			By("Creating NetworkFence to block peer")
-			nf := CreateNetworkFence(ctx, c, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-			By("Waiting for NetworkFence to be applied")
-			WaitForNetworkFenceResult(ctx, c, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			var cidrs []string
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				cidrs = GetFenceCIDRs(ctx, c, env.Provisioner, "")
+			case helpers.FaultInjectorIptables:
+				if IsFullDRMode() {
+					cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, GetK8sClientForCluster(ClusterDR1), GetK8sClientForCluster(ClusterDR2))
+				} else {
+					cidrs = GetFenceCIDRsForFaultInjection(ctx, c)
+				}
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-DIS-005 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or use FENCE_TARGET_SERVICES / node discovery per docs/testing/replication-e2e-suite.md")
+			}
+
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			By(fmt.Sprintf("Fencing peer CIDRs via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
+				time.Sleep(5 * time.Second)
+			}
+
+			DeferCleanup(func() {
+				cleanupCtx := context.Background()
+				if faultProvider != nil {
+					_ = helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider)
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
+				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, c, vrc)
+				DeletePVCWithCleanup(cleanupCtx, c, pvc)
+				DeleteNamespace(cleanupCtx, c, ns)
+			})
 
 			vrName := "vr-dis-fence"
 			By("Creating VolumeReplication (primary) with peer blocked")
@@ -275,18 +321,8 @@ var _ = Describe("DisableVolumeReplication", func() {
 			By("Attempting to delete VR while peer unreachable (disable should fail gracefully)")
 			DeleteVolumeReplicationWithCleanup(ctx, c, vr)
 
-			DeferCleanup(func() {
-				cleanupCtx := context.Background()
-				// Unfence to clean up properly
-				DeleteNetworkFenceWithCleanup(cleanupCtx, c, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, c, nfc)
-				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, c, vrc)
-				DeletePVCWithCleanup(cleanupCtx, c, pvc)
-				DeleteNamespace(cleanupCtx, c, ns)
-			})
-
 			By("L1-DIS-005: Assertion — VR deletion completed (force=false, peer unreachable handled)")
-			err := c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
+			err = c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue(),
 				"VR should be gone after DisableVolumeReplication with unreachable peer")
@@ -295,11 +331,22 @@ var _ = Describe("DisableVolumeReplication", func() {
 
 	Describe("L1-DIS-006: Disable with peer unreachable (force=true)", func() {
 		It("L1-DIS-006: disable replication on primary when peer unreachable (force=true), expect immediate disable", func() {
-			By("L1-DIS-006: NetworkFence blocks peer; create VR, attempt force disable (should succeed immediately)")
+			By("L1-DIS-006: fault injection blocks peer; create VR, attempt force disable (should succeed immediately)")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			if injector == helpers.FaultInjectorNone {
+				Skip("L1-DIS-006 requires fault injection (set E2E_FAULT_INJECTOR to iptables or networkfence)")
+			}
+
 			c := GetK8sClient()
-			By("Checking that the driver supports NetworkFence")
-			if !IsNetworkFenceSupportAvailable() {
-				Skip("L1-DIS-006 requires NetworkFence support. Install NetworkFence CRDs and ensure driver advertises network_fence.NETWORK_FENCE.")
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				if !IsNetworkFenceSupportAvailable() {
+					Skip("L1-DIS-006 (networkfence) requires NetworkFence CRDs and driver network_fence capability.")
+				}
+			case helpers.FaultInjectorIptables:
+				if !helpers.HasPrivilegedDaemonSetSupport(ctx, c) {
+					Skip("L1-DIS-006 (iptables) requires privileged DaemonSet support for iptables fault injection.")
+				}
 			}
 
 			nsName := UniqueNamespace()
@@ -316,21 +363,55 @@ var _ = Describe("DisableVolumeReplication", func() {
 			By("Creating VolumeReplicationClass (snapshot)")
 			vrc := CreateVolumeReplicationClass(ctx, c, vrcName, env.Provisioner, secretName, secretNs, MirroringModeSnapshot)
 
-			nfcName := "nfc-dis-fence-force-" + nsName
-			By("Creating NetworkFenceClass")
-			nfc := CreateNetworkFenceClass(ctx, c, nfcName, env.Provisioner, secretName, secretNs)
-
-			By("Getting fence CIDRs")
-			cidrs := GetFenceCIDRs(ctx, c, env.Provisioner, nfcName)
-			if len(cidrs) == 0 {
-				Skip("L1-DIS-006 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or ensure nodes have InternalIPs for NetworkFence fallback")
+			faultProvider, err := helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     c,
+				RESTConfig: GetRESTConfig(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner": env.Provisioner,
+					"image":       helpers.DefaultIptablesImageWithRegistry,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-DIS-006 (%s): fault injection provider not supported on this cluster", injector))
 			}
 
-			nfName := "nf-dis-fence-force-" + nsName
-			By("Creating NetworkFence to block peer")
-			nf := CreateNetworkFence(ctx, c, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-			By("Waiting for NetworkFence to be applied")
-			WaitForNetworkFenceResult(ctx, c, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
+			var cidrs []string
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				cidrs = GetFenceCIDRs(ctx, c, env.Provisioner, "")
+			case helpers.FaultInjectorIptables:
+				if IsFullDRMode() {
+					cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, GetK8sClientForCluster(ClusterDR1), GetK8sClientForCluster(ClusterDR2))
+				} else {
+					cidrs = GetFenceCIDRsForFaultInjection(ctx, c)
+				}
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-DIS-006 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or use FENCE_TARGET_SERVICES / node discovery per docs/testing/replication-e2e-suite.md")
+			}
+
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			By(fmt.Sprintf("Fencing peer CIDRs via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
+				time.Sleep(5 * time.Second)
+			}
+
+			DeferCleanup(func() {
+				cleanupCtx := context.Background()
+				if faultProvider != nil {
+					_ = helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider)
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
+				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, c, vrc)
+				DeletePVCWithCleanup(cleanupCtx, c, pvc)
+				DeleteNamespace(cleanupCtx, c, ns)
+			})
 
 			vrName := "vr-dis-fence-force"
 			By("Creating VolumeReplication (primary) with peer blocked")
@@ -342,18 +423,8 @@ var _ = Describe("DisableVolumeReplication", func() {
 			By("L1-DIS-006: Attempting to delete VR with force=true (immediate disable expected)")
 			DeleteVolumeReplicationWithCleanup(ctx, c, vr)
 
-			DeferCleanup(func() {
-				cleanupCtx := context.Background()
-				// Unfence to clean up properly
-				DeleteNetworkFenceWithCleanup(cleanupCtx, c, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, c, nfc)
-				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, c, vrc)
-				DeletePVCWithCleanup(cleanupCtx, c, pvc)
-				DeleteNamespace(cleanupCtx, c, ns)
-			})
-
 			By("L1-DIS-006: Assertion — VR deleted successfully (force disable with unreachable peer)")
-			err := c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
+			err = c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue(),
 				"VR should be gone after force DisableVolumeReplication")

--- a/test/e2e/replication/enable_volumereplication_test.go
+++ b/test/e2e/replication/enable_volumereplication_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
@@ -172,61 +171,47 @@ var _ = Describe("EnableVolumeReplication", func() {
 			By("Creating VolumeReplicationClass (snapshot) " + vrcName)
 			vrc := CreateVolumeReplicationClass(ctx, c, vrcName, env.Provisioner, secretName, secretNs, MirroringModeSnapshot)
 
-			var (
-				nfc *csiaddonsv1alpha1.NetworkFenceClass
-				nf  *csiaddonsv1alpha1.NetworkFence
-			)
-			var faultProvider helpers.PeerFenceProvider
-			var cidrs []string
+			faultProvider, err := helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     c,
+				RESTConfig: GetRESTConfig(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner": env.Provisioner,
+					"image":       helpers.DefaultIptablesImageWithRegistry,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-E-003 (%s): fault injection provider not supported on this cluster", injector))
+			}
 
+			var cidrs []string
 			switch injector {
 			case helpers.FaultInjectorNetworkFence:
-				nfcName := "nfc-fence-" + nsName
-				By("Creating NetworkFenceClass " + nfcName + " (same provisioner and secret as VRC)")
-				nfc = CreateNetworkFenceClass(ctx, c, nfcName, env.Provisioner, secretName, secretNs)
-
-				By("Getting fence CIDRs (from FENCE_CIDRS env, CSIAddonsNode status, or node InternalIPs)")
-				cidrs = GetFenceCIDRs(ctx, c, env.Provisioner, nfcName)
-				if len(cidrs) == 0 {
-					Skip("L1-E-003 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or ensure nodes have InternalIPs for NetworkFence fallback")
-				}
-
-				nfName := "nf-fence-" + nsName
-				By("Creating NetworkFence (Fenced) to block node access " + nfName)
-				nf = CreateNetworkFence(ctx, c, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-				By("Waiting for NetworkFence to report Succeeded")
-				WaitForNetworkFenceResult(ctx, c, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
-
+				By("Getting fence CIDRs (from FENCE_CIDRS env, CSIAddonsNode status for any class, or node InternalIPs)")
+				cidrs = GetFenceCIDRs(ctx, c, env.Provisioner, "")
 			case helpers.FaultInjectorIptables:
-				var err error
-				faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
-					Client:     c,
-					RESTConfig: GetRESTConfig(),
-					Namespace:  nsName,
-					ProviderParams: map[string]string{
-						"provisioner": env.Provisioner,
-						"image":       helpers.DefaultIptablesImageWithRegistry,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
-				if !faultProvider.IsSupported(ctx) {
-					Skip("L1-E-003 (iptables): fault injection provider not supported on this cluster")
-				}
-
 				By("Getting fence CIDRs for iptables (FENCE_CIDRS; full-DR: peer backends from FENCE_PEER_SERVICES or FENCE_TARGET_SERVICES on DR2)")
 				if IsFullDRMode() {
 					cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, GetK8sClientForCluster(ClusterDR1), GetK8sClientForCluster(ClusterDR2))
 				} else {
 					cidrs = GetFenceCIDRsForFaultInjection(ctx, c)
 				}
-				if len(cidrs) == 0 {
-					Skip("L1-E-003 could not get CIDRs for iptables: set FENCE_CIDRS, or FENCE_TARGET_SERVICES (e.g. rook-ceph/rook-ceph-active-mons); with DR1+DR2, services are resolved on the peer cluster")
-				}
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-E-003 could not get CIDRs: set FENCE_CIDRS, wait for CSI networkFenceClientStatus, or use FENCE_TARGET_SERVICES / node discovery per docs/testing/replication-e2e-suite.md")
+			}
 
-				By(fmt.Sprintf("Fencing peer CIDRs via iptables: %v", cidrs))
-				for _, cidr := range cidrs {
-					Expect(faultProvider.FenceIP(ctx, cidr, nil)).To(Succeed(), "FenceIP %s", cidr)
-				}
+			fenceParams := map[string]string{
+				"secretName":      secretName,
+				"secretNamespace": secretNs,
+			}
+			By(fmt.Sprintf("Fencing peer CIDRs via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
 				time.Sleep(5 * time.Second)
 			}
 
@@ -236,18 +221,11 @@ var _ = Describe("EnableVolumeReplication", func() {
 
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				if injector == helpers.FaultInjectorNetworkFence && nf != nil {
-					// Unfence first so RBD mirroring can recover before VR/PVC cleanup.
-					DeleteNetworkFenceWithCleanup(cleanupCtx, c, nf)
-				}
 				if faultProvider != nil {
 					_ = helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider)
 					_ = faultProvider.Cleanup(cleanupCtx)
 				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, c, vr)
-				if nfc != nil {
-					DeleteNetworkFenceClassWithCleanup(cleanupCtx, c, nfc)
-				}
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, c, vrc)
 				DeletePVCWithCleanup(cleanupCtx, c, pvc)
 				DeleteNamespace(cleanupCtx, c, ns)
@@ -255,22 +233,16 @@ var _ = Describe("EnableVolumeReplication", func() {
 
 			By("Waiting for VR to report error (peer unreachable)")
 			WaitForVolumeReplicationError(ctx, c, vr)
-			err := c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
+			err = c.Get(ctx, client.ObjectKey{Namespace: nsName, Name: vrName}, vr)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Assertions: GetVolumeReplicationInfo (L1-INFO-005) — peer unreachable returns error in VR status")
 			Expect(hasVolumeReplicationErrorCondition(vr)).To(BeTrue(),
 				"GetVolumeReplicationInfo (L1-INFO-005): VR with fenced/peer unreachable must have error (message or degraded condition)")
 
-			switch injector {
-			case helpers.FaultInjectorNetworkFence:
-				By("Unfencing by setting fenceState to Unfenced")
-				UnfenceNetworkFence(ctx, c, nf)
-			case helpers.FaultInjectorIptables:
-				By("Unfencing by removing iptables rules")
-				for _, cidr := range cidrs {
-					Expect(faultProvider.UnfenceIP(ctx, cidr, nil)).To(Succeed(), "UnfenceIP %s", cidr)
-				}
+			By("Unfencing (NetworkFence CR or iptables rules via PeerFenceProvider)")
+			for _, cidr := range cidrs {
+				Expect(faultProvider.UnfenceIP(ctx, cidr, fenceParams)).To(Succeed(), "UnfenceIP %s", cidr)
 			}
 
 			By("Waiting for controller to retry and EnableVolumeReplication to succeed")

--- a/test/e2e/replication/helpers.go
+++ b/test/e2e/replication/helpers.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"net"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,7 +28,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -71,15 +68,6 @@ const (
 	networkFenceSecretNsKey   = networkFenceParamPrefix + "networkfence-secret-namespace"
 	networkFencePollTimeout   = 120 * time.Second // for WaitForNetworkFenceResult
 	fenceCIDRProbeTimeout     = 30 * time.Second  // wait for CSIAddonsNode CIDRs before skipping L1-E-003
-	// FENCE_TARGET_SERVICES lists "namespace/service" whose backends resolve for single-cluster iptables discovery
-	// (comma-separated). Example: "rook-ceph/rook-ceph-active-mons"
-	fenceTargetServicesEnv = "FENCE_TARGET_SERVICES"
-	// FENCE_PEER_SERVICES lists "namespace/service" resolved on the **peer** cluster in full-DR iptables tests
-	// (same format as FENCE_TARGET_SERVICES). If unset, FENCE_TARGET_SERVICES is reused for peer lookup keys.
-	fencePeerServicesEnv = "FENCE_PEER_SERVICES"
-	// FENCE_AUTO_ENDPOINT_NAMESPACES limits auto-discovery of Endpoints (comma-separated). Default: rook-ceph,csi-addons-system
-	fenceAutoEndpointNamespacesEnv = "FENCE_AUTO_ENDPOINT_NAMESPACES"
-	fenceAutoDiscoveryMaxCIDRs     = 32
 
 	// NetworkFence/NetworkFenceClass finalizers (must match internal/controller/csiaddons/networkfence*.go)
 	networkFenceFinalizer      = "csiaddons.openshift.io/network-fence"
@@ -908,413 +896,74 @@ func CreateNetworkFenceClass(ctx context.Context, c client.Client, name, provisi
 	return nfc
 }
 
-// GetFenceCIDRsForFaultInjection returns CIDRs for the iptables fault injector only (not NetworkFence).
-// Order: 1) FENCE_CIDRS, 2) service/backend IPs (Endpoints + EndpointSlice). Raw cluster node InternalIPs are
-// never used as fence targets (avoids blocking the fencing node); use FENCE_CIDRS if you must target a node IP.
-func GetFenceCIDRsForFaultInjection(ctx context.Context, c client.Client) []string {
-	if cidrs := parseFenceCIDRSFromEnv(); len(cidrs) > 0 {
-		Logf("[DEBUG]", "GetFenceCIDRsForFaultInjection: Using FENCE_CIDRS env: %v", cidrs)
-		return cidrs
-	}
-	Logf("[INFO]", "GetFenceCIDRsForFaultInjection: resolving targets via GetNodeIPsForFencing (iptables: no raw node-IP fence targets)")
-	return GetNodeIPsForFencing(ctx, c)
-}
-
-// GetFenceCIDRsForFaultInjectionPeer resolves fence targets for full-DR iptables only (not NetworkFence).
-// Backends come from the peer cluster; fencing-cluster node InternalIPs are excluded so the API path is not
-// self-fenced. Raw node IPs are never chosen as targets. Order: 1) FENCE_CIDRS, 2) FENCE_PEER_SERVICES or
-// FENCE_TARGET_SERVICES on peerClient.
-func GetFenceCIDRsForFaultInjectionPeer(ctx context.Context, fencingClient, peerClient client.Client) []string {
-	if cidrs := parseFenceCIDRSFromEnv(); len(cidrs) > 0 {
-		Logf("[DEBUG]", "GetFenceCIDRsForFaultInjectionPeer: Using FENCE_CIDRS env: %v", cidrs)
-		return cidrs
-	}
-	fencingNodeIPs := collectNodeInternalIPSet(ctx, fencingClient)
-	keys := parseFencePeerServicesFromEnv()
-	if len(keys) == 0 {
-		Logf("[WARN]", "GetFenceCIDRsForFaultInjectionPeer: set %s or %s (namespace/service list) or FENCE_CIDRS",
-			fencePeerServicesEnv, fenceTargetServicesEnv)
-		return nil
-	}
-	var merged []string
-	for _, key := range keys {
-		ips := collectServiceBackendIPs(ctx, peerClient, key)
-		Logf("[INFO]", "peer fence: %s/%s backend IPs on peer cluster: %v", key.Namespace, key.Name, ips)
-		merged = append(merged, ips...)
-	}
-	out := filterEndpointIPsToCIDRs(merged, fencingNodeIPs)
-	if len(out) > 0 {
-		Logf("[INFO]", "GetFenceCIDRsForFaultInjectionPeer: CIDRs after excluding fencing-cluster node InternalIPs: %v", out)
-		return capFenceCIDRList(out)
-	}
-	if len(merged) > 0 {
-		Logf("[WARN]", "GetFenceCIDRsForFaultInjectionPeer: all peer backend IPs match a fencing-cluster node InternalIP; nothing left to fence")
-	} else {
-		Logf("[WARN]", "GetFenceCIDRsForFaultInjectionPeer: no backend IPs from peer services (check Endpoints/EndpointSlices on peer)")
-	}
-	return nil
-}
-
-// GetFenceCIDRs returns CIDRs for the NetworkFence fault injector only (iptables uses GetFenceCIDRsForFaultInjection*).
-// Order: 1) FENCE_CIDRS, 2) CSIAddonsNode status.networkFenceClientStatus for networkFenceClassName, 3) node
-// InternalIPs as host routes (CSI did not publish CIDRs in time). Iptables never uses this path and never falls
-// back to raw node IPs as fence targets. For full-DR, if the NetworkFenceClass lives on c but peer nodes are on
-// another cluster, use GetFenceCIDRsWithPeerNodeClient.
+// GetFenceCIDRs returns CIDRs to use for NetworkFence. It first checks env FENCE_CIDRS (comma-separated).
+// If unset, it waits up to fenceCIDRProbeTimeout for CSIAddonsNodes (matching provisioner) to have
+// status.networkFenceClientStatus for networkFenceClassName. If still empty, falls back to node InternalIPs
+// (useful when driver does not advertise GET_CLIENTS_TO_FENCE, e.g. CephFS). Returns nil only when all
+// sources fail (caller should skip the test).
 func GetFenceCIDRs(ctx context.Context, c client.Client, provisioner, networkFenceClassName string) []string {
-	return getFenceCIDRs(ctx, c, provisioner, networkFenceClassName, nil)
-}
-
-// GetFenceCIDRsWithPeerNodeClient is like GetFenceCIDRs but, when falling back to node InternalIPs after a CSI
-// timeout, uses peerNodeClient for node discovery instead of c. Pass the peer cluster client when c is the
-// cluster where you list CSIAddonsNode / create NetworkFenceClass but the fenced peer is the other cluster.
-func GetFenceCIDRsWithPeerNodeClient(ctx context.Context, c, peerNodeClient client.Client, provisioner, networkFenceClassName string) []string {
-	return getFenceCIDRs(ctx, c, provisioner, networkFenceClassName, peerNodeClient)
-}
-
-func getFenceCIDRs(ctx context.Context, c client.Client, provisioner, networkFenceClassName string, peerNodeClient client.Client) []string {
-	if cidrs := parseFenceCIDRSFromEnv(); len(cidrs) > 0 {
-		Logf("[DEBUG]", "GetFenceCIDRs: Using FENCE_CIDRS env var: %v", cidrs)
-		return cidrs
+	if s := os.Getenv("FENCE_CIDRS"); s != "" {
+		var cidrs []string
+		for _, part := range strings.Split(s, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				cidrs = append(cidrs, part)
+			}
+		}
+		if len(cidrs) > 0 {
+			return cidrs
+		}
 	}
-	Logf("[DEBUG]", "GetFenceCIDRs: FENCE_CIDRS not set, checking CSIAddonsNode for networkFenceClientStatus (provisioner=%s, class=%s)", provisioner, networkFenceClassName)
 	deadline := time.Now().Add(fenceCIDRProbeTimeout)
 	var cidrs []string
 	for time.Now().Before(deadline) {
 		list := &csiaddonsv1alpha1.CSIAddonsNodeList{}
 		err := c.List(ctx, list)
 		if err != nil {
-			Logf("[DEBUG]", "GetFenceCIDRs: Failed to list CSIAddonsNodes: %v", err)
 			time.Sleep(pollInterval)
 			continue
 		}
-		Logf("[DEBUG]", "GetFenceCIDRs: Found %d CSIAddonsNodes", len(list.Items))
 		cidrs = nil
 		for i := range list.Items {
 			node := &list.Items[i]
-			Logf("[DEBUG]", "GetFenceCIDRs: Checking CSIAddonsNode %s (driver=%s)", node.Name, node.Spec.Driver.Name)
 			if node.Spec.Driver.Name != provisioner {
 				continue
 			}
-			Logf("[DEBUG]", "GetFenceCIDRs: Driver matches, checking networkFenceClientStatus (%d statuses)", len(node.Status.NetworkFenceClientStatus))
 			for _, nfcs := range node.Status.NetworkFenceClientStatus {
-				Logf("[DEBUG]", "GetFenceCIDRs:   NetworkFenceClass: %s (looking for %s)", nfcs.NetworkFenceClassName, networkFenceClassName)
 				if nfcs.NetworkFenceClassName != networkFenceClassName {
 					continue
 				}
-				Logf("[DEBUG]", "GetFenceCIDRs:   Class matches, found %d client details", len(nfcs.ClientDetails))
 				for _, detail := range nfcs.ClientDetails {
 					cidrs = append(cidrs, detail.Cidrs...)
 				}
 			}
 		}
 		if len(cidrs) > 0 {
-			Logf("[INFO]", "GetFenceCIDRs: Found CIDRs from CSIAddonsNode: %v", cidrs)
 			return cidrs
 		}
-		Logf("[DEBUG]", "GetFenceCIDRs: No CIDRs found yet, retrying in %v...", pollInterval)
 		time.Sleep(pollInterval)
 	}
-	Logf("[WARN]", "GetFenceCIDRs: Timeout waiting for CSIAddonsNode networkFenceClientStatus for class %q", networkFenceClassName)
-	nodeClient := c
-	if peerNodeClient != nil {
-		nodeClient = peerNodeClient
-		Logf("[INFO]", "GetFenceCIDRs: Using peer cluster client for node-IP fallback (not the CSI list client)")
-	}
-	fallback := collectAllNodeInternalIPCIDRs(ctx, nodeClient)
-	if len(fallback) == 0 {
-		Logf("[WARN]", "GetFenceCIDRs: Node InternalIP fallback found no nodes; set FENCE_CIDRS explicitly")
-		return nil
-	}
-	Logf("[WARN]", "GetFenceCIDRs: Using node InternalIP fallback CIDRs (driver did not publish client CIDRs in time): %v", fallback)
-	return capFenceCIDRList(fallback)
+	// Fallback: use node InternalIPs when driver does not advertise GET_CLIENTS_TO_FENCE (e.g. CephFS)
+	return GetNodeIPsForFencing(ctx, c)
 }
 
-// collectAllNodeInternalIPCIDRs returns each node's primary InternalIP as a host route (IPv4 /32, IPv6 /128), sorted.
-func collectAllNodeInternalIPCIDRs(ctx context.Context, c client.Client) []string {
-	set := collectNodeInternalIPSet(ctx, c)
-	if len(set) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(set))
-	for ipStr := range set {
-		if ipStr == "" {
-			continue
-		}
-		parsed := net.ParseIP(ipStr)
-		if parsed == nil {
-			continue
-		}
-		if parsed.To4() != nil {
-			out = append(out, fmt.Sprintf("%s/32", ipStr))
-		} else {
-			out = append(out, fmt.Sprintf("%s/128", ipStr))
-		}
-	}
-	sort.Strings(out)
-	return out
-}
-
-// GetNodeIPsForFencing resolves iptables fence CIDRs from service backends and auto-discovered Endpoints:
-// 1) FENCE_TARGET_SERVICES (Endpoints + EndpointSlice); 2) auto-discovered Endpoints in FENCE_AUTO_ENDPOINT_NAMESPACES.
-// Node InternalIPs are excluded from picks; raw node IPs are never used as iptables fence targets (use FENCE_CIDRS to target a node explicitly).
+// GetNodeIPsForFencing returns node InternalIPs as /32 CIDRs. Used as fallback when
+// FENCE_CIDRS is unset and CSIAddonsNode networkFenceClientStatus is empty.
 func GetNodeIPsForFencing(ctx context.Context, c client.Client) []string {
-	nodeIPs := collectNodeInternalIPSet(ctx, c)
-	Logf("[DEBUG]", "GetNodeIPsForFencing: node InternalIPs (excluded from endpoint picks): %v", sortedKeys(nodeIPs))
-
-	if cidrs := fenceCIDRsFromConfiguredTargetServices(ctx, c, nodeIPs); len(cidrs) > 0 {
-		return capFenceCIDRList(cidrs)
-	}
-	if cidrs := fenceCIDRsFromAutoDiscoveredEndpoints(ctx, c, nodeIPs); len(cidrs) > 0 {
-		return capFenceCIDRList(cidrs)
-	}
-
-	Logf("[WARN]", "GetNodeIPsForFencing: no usable backend IPs after excluding node InternalIPs; set %s or FENCE_CIDRS (iptables does not use raw node IPs as targets)",
-		fenceTargetServicesEnv)
-	return nil
-}
-
-func parseFenceCIDRSFromEnv() []string {
-	s := strings.TrimSpace(os.Getenv("FENCE_CIDRS"))
-	if s == "" {
+	nodeList := &corev1.NodeList{}
+	if err := c.List(ctx, nodeList); err != nil {
 		return nil
 	}
 	var cidrs []string
-	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
-		if part != "" {
-			cidrs = append(cidrs, part)
-		}
-	}
-	return cidrs
-}
-
-func collectNodeInternalIPSet(ctx context.Context, c client.Client) map[string]struct{} {
-	out := make(map[string]struct{})
-	nodeList := &corev1.NodeList{}
-	if err := c.List(ctx, nodeList); err != nil {
-		Logf("[DEBUG]", "collectNodeInternalIPSet: list nodes: %v", err)
-		return out
-	}
-	for i := range nodeList.Items {
-		node := &nodeList.Items[i]
+	for _, node := range nodeList.Items {
 		for _, addr := range node.Status.Addresses {
 			if addr.Type == corev1.NodeInternalIP && addr.Address != "" {
-				out[addr.Address] = struct{}{}
+				cidrs = append(cidrs, addr.Address+"/32")
 				break
 			}
 		}
 	}
-	return out
-}
-
-func sortedKeys(m map[string]struct{}) []string {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func parseFenceTargetServicesFromEnv() []client.ObjectKey {
-	return parseFenceNamespaceServiceList(os.Getenv(fenceTargetServicesEnv), fenceTargetServicesEnv)
-}
-
-// parseFencePeerServicesFromEnv returns service keys for peer-cluster lookup: FENCE_PEER_SERVICES if set,
-// otherwise the same keys as FENCE_TARGET_SERVICES.
-func parseFencePeerServicesFromEnv() []client.ObjectKey {
-	s := strings.TrimSpace(os.Getenv(fencePeerServicesEnv))
-	if s != "" {
-		return parseFenceNamespaceServiceList(s, fencePeerServicesEnv)
-	}
-	return parseFenceTargetServicesFromEnv()
-}
-
-func parseFenceNamespaceServiceList(raw, envVar string) []client.ObjectKey {
-	s := strings.TrimSpace(raw)
-	if s == "" {
-		return nil
-	}
-	var keys []client.ObjectKey
-	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		ns, name, ok := strings.Cut(part, "/")
-		if !ok {
-			Logf("[WARNING]", "%s: skip %q (want namespace/service)", envVar, part)
-			continue
-		}
-		ns, name = strings.TrimSpace(ns), strings.TrimSpace(name)
-		if ns == "" || name == "" {
-			continue
-		}
-		keys = append(keys, client.ObjectKey{Namespace: ns, Name: name})
-	}
-	return keys
-}
-
-func ipToFenceCIDR(ip string) string {
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		return ""
-	}
-	if parsed.To4() == nil {
-		return ip + "/128"
-	}
-	return ip + "/32"
-}
-
-func filterEndpointIPsToCIDRs(ips []string, nodeIPs map[string]struct{}) []string {
-	seen := make(map[string]struct{})
-	var out []string
-	for _, ip := range ips {
-		if _, onNode := nodeIPs[ip]; onNode {
-			Logf("[DEBUG]", "filterEndpointIPs: skip %s (matches node InternalIP — avoids fencing apiserver/kubelet host)", ip)
-			continue
-		}
-		cidr := ipToFenceCIDR(ip)
-		if cidr == "" {
-			continue
-		}
-		if _, ok := seen[cidr]; ok {
-			continue
-		}
-		seen[cidr] = struct{}{}
-		out = append(out, cidr)
-	}
-	return out
-}
-
-// collectServiceBackendIPs collects backend IPs from EndpointSlices labeled for the Service.
-// (v1 Endpoints is deprecated in Kubernetes 1.33+; EndpointSlice has been available since 1.21.)
-func collectServiceBackendIPs(ctx context.Context, c client.Client, key client.ObjectKey) []string {
-	seen := make(map[string]struct{})
-	var ips []string
-	add := func(ip string) {
-		if ip == "" {
-			return
-		}
-		if _, ok := seen[ip]; ok {
-			return
-		}
-		seen[ip] = struct{}{}
-		ips = append(ips, ip)
-	}
-	sliceList := &discoveryv1.EndpointSliceList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(key.Namespace),
-		client.MatchingLabels{discoveryv1.LabelServiceName: key.Name},
-	}
-	if err := c.List(ctx, sliceList, listOpts...); err != nil {
-		Logf("[DEBUG]", "collectServiceBackendIPs: list EndpointSlices %s/%s: %v", key.Namespace, key.Name, err)
-		return ips
-	}
-	for i := range sliceList.Items {
-		for j := range sliceList.Items[i].Endpoints {
-			for _, addr := range sliceList.Items[i].Endpoints[j].Addresses {
-				add(addr)
-			}
-		}
-	}
-	return ips
-}
-
-func fenceCIDRsFromConfiguredTargetServices(ctx context.Context, c client.Client, nodeIPs map[string]struct{}) []string {
-	keys := parseFenceTargetServicesFromEnv()
-	if len(keys) == 0 {
-		return nil
-	}
-	var merged []string
-	for _, key := range keys {
-		ips := collectServiceBackendIPs(ctx, c, key)
-		Logf("[INFO]", "%s: service %s/%s backend IPs (Endpoints+EndpointSlice): %v", fenceTargetServicesEnv, key.Namespace, key.Name, ips)
-		merged = append(merged, ips...)
-	}
-	out := filterEndpointIPsToCIDRs(merged, nodeIPs)
-	if len(out) > 0 {
-		Logf("[INFO]", "%s: fence CIDRs after excluding node InternalIPs: %v", fenceTargetServicesEnv, out)
-	} else if len(merged) > 0 {
-		Logf("[WARN]", "%s: all backend IPs matched node InternalIPs; nothing to fence from configured services", fenceTargetServicesEnv)
-	}
-	return out
-}
-
-func autoDiscoverFenceEndpointNamespaces() []string {
-	s := strings.TrimSpace(os.Getenv(fenceAutoEndpointNamespacesEnv))
-	if s == "" {
-		return []string{"rook-ceph", "csi-addons-system"}
-	}
-	var ns []string
-	for _, part := range strings.Split(s, ",") {
-		if t := strings.TrimSpace(part); t != "" {
-			ns = append(ns, t)
-		}
-	}
-	if len(ns) == 0 {
-		return []string{"rook-ceph", "csi-addons-system"}
-	}
-	return ns
-}
-
-func endpointNameLikelyStorageOrCSI(name string) bool {
-	n := strings.ToLower(name)
-	switch {
-	case n == "kubernetes":
-		return false
-	case strings.HasPrefix(n, "rook-ceph"):
-		return true
-	case strings.Contains(n, "csi-addons"):
-		return true
-	}
-	for _, tok := range []string{"mon", "mgr", "ceph", "rbd", "osd", "mds", "nfs", "csi"} {
-		if strings.Contains(n, tok) {
-			return true
-		}
-	}
-	return false
-}
-
-func fenceCIDRsFromAutoDiscoveredEndpoints(ctx context.Context, c client.Client, nodeIPs map[string]struct{}) []string {
-	var allIPs []string
-	for _, ns := range autoDiscoverFenceEndpointNamespaces() {
-		epList := &corev1.EndpointsList{}
-		if err := c.List(ctx, epList, client.InNamespace(ns)); err != nil {
-			Logf("[DEBUG]", "auto-discover Endpoints in namespace %q: %v", ns, err)
-			continue
-		}
-		for i := range epList.Items {
-			ep := &epList.Items[i]
-			if len(ep.Subsets) == 0 || !endpointNameLikelyStorageOrCSI(ep.Name) {
-				continue
-			}
-			for _, sub := range ep.Subsets {
-				for _, a := range sub.Addresses {
-					if a.IP != "" {
-						allIPs = append(allIPs, a.IP)
-					}
-				}
-			}
-		}
-	}
-	out := filterEndpointIPsToCIDRs(allIPs, nodeIPs)
-	if len(out) > 0 {
-		Logf("[INFO]", "GetNodeIPsForFencing: auto-discovered CIDRs from Endpoints (%s=%q): %v",
-			fenceAutoEndpointNamespacesEnv, strings.Join(autoDiscoverFenceEndpointNamespaces(), ","), out)
-	}
-	return out
-}
-
-func capFenceCIDRList(cidrs []string) []string {
-	if len(cidrs) <= fenceAutoDiscoveryMaxCIDRs {
-		return cidrs
-	}
-	Logf("[WARN]", "capping fence CIDR list from %d to %d (set FENCE_CIDRS to be explicit)", len(cidrs), fenceAutoDiscoveryMaxCIDRs)
-	return append([]string(nil), cidrs[:fenceAutoDiscoveryMaxCIDRs]...)
+	return cidrs
 }
 
 // CreateNetworkFence creates a NetworkFence that blocks (Fenced) or unblocks (Unfenced) the given CIDRs.
@@ -1352,29 +1001,20 @@ func CreateNetworkFenceAndWait(ctx context.Context, c client.Client, namespace, 
 	nfcName := "nfc-" + UniqueNamespace()
 	nfName := "nf-" + UniqueNamespace()
 
-	Logf("[DEBUG]", "CreateNetworkFenceAndWait: Creating NetworkFenceClass: %s", nfcName)
 	// Create NetworkFenceClass
 	nfc := CreateNetworkFenceClass(ctx, c, nfcName, provisioner, secretName, secretNamespace)
-	Logf("[INFO]", "CreateNetworkFenceAndWait: NetworkFenceClass created: %s", nfcName)
 
 	// Get CIDRs to fence
-	Logf("[DEBUG]", "CreateNetworkFenceAndWait: Getting fence CIDRs for class: %s", nfcName)
 	cidrs := GetFenceCIDRs(ctx, c, provisioner, nfcName)
 	if len(cidrs) == 0 {
-		Logf("[ERROR]", "CreateNetworkFenceAndWait: No CIDRs found for fencing! Cannot proceed with NetworkFence creation")
 		Expect(cidrs).NotTo(BeEmpty(), "Failed to get CIDRs for network fencing")
 	}
-	Logf("[INFO]", "CreateNetworkFenceAndWait: Retrieved %d CIDRs for fencing: %v", len(cidrs), cidrs)
 
 	// Create NetworkFence with Fenced state
-	Logf("[DEBUG]", "CreateNetworkFenceAndWait: Creating NetworkFence: %s with CIDRs: %v", nfName, cidrs)
 	nf := CreateNetworkFence(ctx, c, nfName, nfcName, cidrs, csiaddonsv1alpha1.Fenced)
-	Logf("[INFO]", "CreateNetworkFenceAndWait: NetworkFence created: %s", nfName)
 
 	// Wait for fence to be applied
-	Logf("[DEBUG]", "CreateNetworkFenceAndWait: Waiting for NetworkFence result (timeout=2 min)...")
 	WaitForNetworkFenceResult(ctx, c, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
-	Logf("[INFO]", "CreateNetworkFenceAndWait: NetworkFence %s result succeeded", nfName)
 
 	return nfc, nf
 }
@@ -1421,64 +1061,6 @@ func RemoveFinalizerFromNetworkFence(ctx context.Context, c client.Client, nf *c
 	})
 }
 
-// logVRState logs comprehensive state information about a VolumeReplication resource in CRD format
-func logVRState(vr *replicationv1alpha1.VolumeReplication, stageName string) {
-	if vr == nil {
-		return
-	}
-
-	// Format conditions as Condition=Status pairs
-	conditionsStr := "NO CONDITIONS"
-	if len(vr.Status.Conditions) > 0 {
-		var condDetails []string
-		for _, cond := range vr.Status.Conditions {
-			condStr := fmt.Sprintf("%s=%s", cond.Type, cond.Status)
-			condDetails = append(condDetails, condStr)
-		}
-		conditionsStr = strings.Join(condDetails, " ")
-	}
-
-	// Format message
-	message := vr.Status.Message
-	if message == "" {
-		message = "-"
-	}
-
-	// Log data line in CRD table format:
-	// NAMESPACE              NAME              STATE        CONDITIONS                               MESSAGE
-	Logf("[INFO]", "%-30s %-30s %-15s %-40s %s",
-		vr.Namespace, vr.Name, vr.Status.State, conditionsStr, message)
-}
-
-// logVRState logs comprehensive state information about a VolumeReplication resource in CRD format
-func logVRState(vr *replicationv1alpha1.VolumeReplication, stageName string) {
-	if vr == nil {
-		return
-	}
-
-	// Format conditions as Condition=Status pairs
-	conditionsStr := "NO CONDITIONS"
-	if len(vr.Status.Conditions) > 0 {
-		var condDetails []string
-		for _, cond := range vr.Status.Conditions {
-			condStr := fmt.Sprintf("%s=%s", cond.Type, cond.Status)
-			condDetails = append(condDetails, condStr)
-		}
-		conditionsStr = strings.Join(condDetails, " ")
-	}
-
-	// Format message
-	message := vr.Status.Message
-	if message == "" {
-		message = "-"
-	}
-
-	// Log data line in CRD table format:
-	// NAMESPACE              NAME              STATE        CONDITIONS                               MESSAGE
-	Logf("[INFO]", "%-30s %-30s %-15s %-40s %s",
-		vr.Namespace, vr.Name, vr.Status.State, conditionsStr, message)
-}
-
 // DeleteNetworkFenceWithCleanup unfences the CIDRs (sets fenceState: Unfenced), then deletes the
 // NetworkFence. Deletion no longer triggers UnfenceClusterNetwork; unfence must be explicit.
 // If vrs is provided (non-nil), waits for each VR's Degraded condition to become False before deletion.
@@ -1498,101 +1080,25 @@ func DeleteNetworkFenceWithCleanup(ctx context.Context, c client.Client, nf *csi
 		UnfenceNetworkFence(ctx, c, nf)
 		// Wait for unfence operation to complete before deletion
 		WaitForNetworkFenceResult(ctx, c, nf, csiaddonsv1alpha1.FencingOperationResultSucceeded)
-
 		// If VRs provided, wait for them to recover (Degraded=False) instead of hardcoded sleep
-		// After unfencing, RBD mirror needs time to detect connectivity and process state updates
-		if len(vrs) > 0 {
-			Logf("[INFO]", "NetworkFence unfenced successfully, allowing RBD mirror time to detect connectivity restoration")
-			// Give RBD mirror a moment to process the unfence and detect connectivity is restored
-			time.Sleep(3 * time.Second)
-
-			Logf("[INFO]", "")
-			Logf("[INFO]", "==== VR STATE BEFORE UNFENCING ====")
-			Logf("[INFO]", "%-30s %-30s %-15s %-40s %s", "NAMESPACE", "NAME", "STATE", "CONDITIONS", "MESSAGE")
-			for _, vr := range vrs {
-				if vr == nil {
-					continue
-				}
+		for _, vr := range vrs {
+			if vr == nil {
+				continue
+			}
+			Eventually(func() bool {
 				err := c.Get(ctx, client.ObjectKeyFromObject(vr), vr)
 				if err != nil {
-					Logf("[WARNING]", "Failed to fetch VR %s/%s before unfence: %v", vr.Namespace, vr.Name, err)
-					continue
+					return false
 				}
-				logVRState(vr, "PRE-UNFENCE")
-			}
-
-			Logf("[INFO]", "")
-			Logf("[INFO]", "==== VR STATE IMMEDIATELY AFTER UNFENCING ====")
-			Logf("[INFO]", "%-30s %-30s %-15s %-40s %s", "NAMESPACE", "NAME", "STATE", "CONDITIONS", "MESSAGE")
-			for _, vr := range vrs {
-				if vr == nil {
-					continue
-				}
-				err := c.Get(ctx, client.ObjectKeyFromObject(vr), vr)
-				if err != nil {
-					Logf("[WARNING]", "Failed to fetch VR %s/%s immediately after unfence: %v", vr.Namespace, vr.Name, err)
-					continue
-				}
-				logVRState(vr, "POST-UNFENCE-IMMEDIATE")
-			}
-
-			Logf("[INFO]", "Starting recovery verification: waiting for VR Degraded=False")
-
-			firstPoll := true
-			for _, vr := range vrs {
-				if vr == nil {
-					continue
-				}
-				pollCount := 0
-				Eventually(func() bool {
-					pollCount++
-					err := c.Get(ctx, client.ObjectKeyFromObject(vr), vr)
-					if err != nil {
-						Logf("[DEBUG]", "[Poll %2d] Failed to fetch VR %s/%s: %v", pollCount, vr.Namespace, vr.Name, err)
-						return false
+				// Check that VR is no longer degraded (Degraded=False)
+				for _, cond := range vr.Status.Conditions {
+					if cond.Type == "Degraded" {
+						return cond.Status == metav1.ConditionFalse
 					}
-
-					// Log header only on first poll to avoid clutter
-					if pollCount == 1 && firstPoll {
-						Logf("[INFO]", "")
-						Logf("[INFO]", "==== VR RECOVERY MONITORING (polling every 5s, timeout 300s) ====")
-						Logf("[INFO]", "%-30s %-30s %-15s %-40s %s", "NAMESPACE", "NAME", "STATE", "CONDITIONS", "MESSAGE")
-						firstPoll = false
-					}
-
-					// Log current state for debugging with all details
-					logVRState(vr, fmt.Sprintf("RECOVERY-POLL-%d", pollCount))
-
-					// VR is recovered when Degraded is False (or condition absent = true)
-					for _, cond := range vr.Status.Conditions {
-						if cond.Type == replicationv1alpha1.ConditionDegraded {
-							if cond.Status == metav1.ConditionFalse {
-								Logf("[INFO]", "✓ VR %s/%s HAS RECOVERED: Degraded=False", vr.Namespace, vr.Name)
-								return true
-							}
-							// Still degraded, continue waiting
-							return false
-						}
-					}
-					// No Degraded condition means VR is healthy/recovered
-					Logf("[INFO]", "✓ VR %s/%s HAS RECOVERED: Degraded condition absent", vr.Namespace, vr.Name)
-					return true
-				}, 300*time.Second, 5*time.Second).Should(BeTrue(),
-					"VR %s/%s health should recover (Degraded=False) after unfencing", vr.Namespace, vr.Name)
-
-				// Log final state after recovery
-				err := c.Get(ctx, client.ObjectKeyFromObject(vr), vr)
-				if err == nil {
-					if firstPoll {
-						Logf("[INFO]", "")
-						Logf("[INFO]", "==== VR FINAL STATE (RECOVERED) ====")
-						Logf("[INFO]", "%-30s %-30s %-15s %-40s %s", "NAMESPACE", "NAME", "STATE", "CONDITIONS", "MESSAGE")
-						firstPoll = false
-					}
-					logVRState(vr, "FINAL-RECOVERED")
 				}
-			}
-			Logf("[INFO]", "All VRs recovered after unfencing, proceeding with deletion")
+				return false
+			}, 200*time.Second, 10*time.Second).Should(BeTrue(),
+				"VR %s/%s health should recover (Degraded=False) after unfencing", vr.Namespace, vr.Name)
 		}
 	}
 	_ = c.Delete(ctx, nf)

--- a/test/e2e/replication/helpers.go
+++ b/test/e2e/replication/helpers.go
@@ -18,6 +18,7 @@ package replication
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"os"
@@ -39,6 +40,7 @@ import (
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	e2ehelpers "github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
 
 const (
@@ -1647,4 +1649,18 @@ func DeleteNetworkFenceClassWithCleanup(ctx context.Context, c client.Client, nf
 	if err := c.Get(ctx, key, nfc); err == nil {
 		RemoveFinalizerFromNetworkFenceClass(ctx, c, nfc)
 	}
+}
+
+// IptablesBaselinesOrGinkgoSkip runs e2ehelpers.EstablishIptablesConnectivityBaselines and maps the result to
+// ginkgo Skip or Fail. Baseline rules live in test/e2e/helpers; this function lives in package replication
+// because generic helpers must not import Ginkgo.
+func IptablesBaselinesOrGinkgoSkip(ctx context.Context, injector e2ehelpers.FaultInjectorType, faultProvider e2ehelpers.PeerFenceProvider, cidrs []string) map[string]*e2ehelpers.ConnectivityBaseline {
+	m, err := e2ehelpers.EstablishIptablesConnectivityBaselines(ctx, injector, faultProvider, cidrs)
+	if err != nil {
+		if stderrors.Is(err, e2ehelpers.ErrIptablesBaselineSkipEnvironment) {
+			ginkgo.Skip("fence baseline: " + err.Error())
+		}
+		ginkgo.Fail(fmt.Sprintf("fence baseline: %v", err), 1)
+	}
+	return m
 }

--- a/test/e2e/replication/promote_volumereplication_test.go
+++ b/test/e2e/replication/promote_volumereplication_test.go
@@ -19,7 +19,6 @@ package replication
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,44 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
-
-// establishIptablesFenceBaselines records which probes (ping / ip route) succeed before fencing.
-// Skips only when the cluster path to the peer is unusable for baseline (no probe succeeded — e.g. ICMP blocked everywhere).
-// Timeouts, API errors, or missing CSI_BASELINE are test/infrastructure failures and fail the spec (not Skip).
-func establishIptablesFenceBaselines(ctx context.Context, faultProvider helpers.PeerFenceProvider, cidrs []string) map[string]*helpers.ConnectivityBaseline {
-	if helpers.GetFaultInjectorTypeFromEnv() != helpers.FaultInjectorIptables {
-		return nil
-	}
-	out := make(map[string]*helpers.ConnectivityBaseline, len(cidrs))
-	for _, cidr := range cidrs {
-		b, err := faultProvider.EstablishConnectivityBaseline(ctx, cidr)
-		if err != nil {
-			if iptablesBaselineErrIsSkipEnvironment(err) {
-				Skip("fence baseline: " + err.Error())
-			}
-			Fail(fmt.Sprintf("fence baseline failed (expected reachable path to peer before fence; fix probe/job or networking): %v", err), 1)
-		}
-		out[cidr] = b
-	}
-	return out
-}
-
-func iptablesBaselineErrIsSkipEnvironment(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "no probe succeeded") ||
-		strings.Contains(msg, "cannot verify fencing")
-}
-
-func fenceBaselineRef(m map[string]*helpers.ConnectivityBaseline, cidr string) *helpers.ConnectivityBaseline {
-	if m == nil {
-		return nil
-	}
-	return m[cidr]
-}
 
 var _ = Describe("PromoteVolumeReplication", func() {
 	var ctx context.Context
@@ -126,13 +90,8 @@ var _ = Describe("PromoteVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
-
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR2, nf, vrDR2)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR2, nfc)
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -445,22 +404,13 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			var cidrs []string
 
 			DeferCleanup(func() {
-				cleanupCtx := context.Background() // Collect fault injection logs for debugging before cleanup
-				if faultProvider != nil {
-					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
-						Logf("[WARNING]", "Failed to collect fault injection logs during L1-PROM-004 cleanup: %v", err)
-					}
-				} // Collect fault injection logs for debugging before cleanup
+				cleanupCtx := context.Background()
 				if faultProvider != nil {
 					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
 						Logf("[WARNING]", "Failed to collect fault injection logs during L1-PROM-003 cleanup: %v", err)
 					}
-				}
-				// Clean up any remaining fences during cleanup
-				if faultProvider != nil && len(cidrs) > 0 {
-					for _, cidr := range cidrs {
-						_ = faultProvider.UnfenceIP(cleanupCtx, cidr, nil)
-					}
+					// Full provider teardown: unfence tracked CIDRs, staged REJECT sweep, ConfigMap — not only per-CIDR UnfenceIP.
+					_ = faultProvider.Cleanup(cleanupCtx)
 				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
@@ -477,7 +427,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			if helpers.GetFaultInjectorTypeFromEnv() == helpers.FaultInjectorIptables {
 				cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR2, cDR1)
 			} else {
-				cidrs = GetFenceCIDRs(ctx, cDR1, env.Provisioner, "temp-nfc-"+nsName)
+				cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR2, cDR1, env.Provisioner, "")
 			}
 			if len(cidrs) == 0 {
 				Skip("L1-PROM-003 could not get CIDRs: for iptables set FENCE_CIDRS or FENCE_PEER_SERVICES/FENCE_TARGET_SERVICES; for NetworkFence set FENCE_CIDRS, wait for CSI client CIDRs, or ensure DR1 has node InternalIPs for fallback")
@@ -487,20 +437,24 @@ var _ = Describe("PromoteVolumeReplication", func() {
 
 			By("[DR2] Initializing fault injection provider")
 			faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
-				Type:      helpers.FaultInjectorIptables,
-				Client:    cDR2,
-				Namespace: nsName,
+				Type:       helpers.GetFaultInjectorTypeFromEnv(),
+				Client:     cDR2,
+				RESTConfig: GetRESTConfigDR2(),
+				Namespace:  nsName,
 				ProviderParams: map[string]string{
-					"image": helpers.DefaultIptablesImageWithRegistry,
+					"provisioner":     env.Provisioner,
+					"cluster_context": "DR2",
+					"image":           helpers.DefaultIptablesImageWithRegistry,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred(), "Failed to create fault injection provider")
 
-			fenceBaselines := establishIptablesFenceBaselines(ctx, faultProvider, cidrs)
+			fenceBaselines := IptablesBaselinesOrGinkgoSkip(ctx, helpers.GetFaultInjectorTypeFromEnv(), faultProvider, cidrs)
 
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
 			By("[DR2] Fencing peer cluster to simulate network partition")
 			for _, cidr := range cidrs {
-				err = faultProvider.FenceIP(ctx, cidr, nil)
+				err = faultProvider.FenceIP(ctx, cidr, fenceParams)
 				Expect(err).NotTo(HaveOccurred(), "Failed to fence CIDR %s", cidr)
 			}
 
@@ -509,7 +463,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			Eventually(func() bool {
 				lastFenceVerifyReason = ""
 				for _, cidr := range cidrs {
-					fenced, err := faultProvider.VerifyConnectivity(ctx, cidr, true, fenceBaselineRef(fenceBaselines, cidr))
+					fenced, err := faultProvider.VerifyConnectivity(ctx, cidr, true, helpers.BaselineForCIDR(fenceBaselines, cidr))
 					if err != nil {
 						lastFenceVerifyReason = fmt.Sprintf("VerifyConnectivity failed for %s: %v", cidr, err)
 						return false
@@ -546,7 +500,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 
 			By("[DR2] Unfencing peer cluster to restore connectivity")
 			for _, cidr := range cidrs {
-				err = faultProvider.UnfenceIP(ctx, cidr, nil)
+				err = faultProvider.UnfenceIP(ctx, cidr, fenceParams)
 				Expect(err).NotTo(HaveOccurred(), "Failed to unfence CIDR %s", cidr)
 			}
 
@@ -555,7 +509,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			Eventually(func() bool {
 				lastUnfenceVerifyReason003 = ""
 				for _, cidr := range cidrs {
-					connected, err := faultProvider.VerifyConnectivity(ctx, cidr, false, fenceBaselineRef(fenceBaselines, cidr))
+					connected, err := faultProvider.VerifyConnectivity(ctx, cidr, false, helpers.BaselineForCIDR(fenceBaselines, cidr))
 					if err != nil {
 						lastUnfenceVerifyReason003 = fmt.Sprintf("VerifyConnectivity failed for %s: %v", cidr, err)
 						return false
@@ -667,13 +621,14 @@ var _ = Describe("PromoteVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
-
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR2, nf, vrDR2)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR2, nfc)
+				if faultProvider != nil {
+					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
+						Logf("[WARNING]", "Failed to collect fault injection logs during L1-PROM-004 cleanup: %v", err)
+					}
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -687,10 +642,12 @@ var _ = Describe("PromoteVolumeReplication", func() {
 
 			By("[DR2] Initializing fault injection provider")
 			faultConfig := helpers.FaultInjectionConfig{
-				Type:      helpers.FaultInjectorIptables,
-				Client:    cDR2,
-				Namespace: nsName,
+				Type:       helpers.GetFaultInjectorTypeFromEnv(),
+				Client:     cDR2,
+				RESTConfig: GetRESTConfigDR2(),
+				Namespace:  nsName,
 				ProviderParams: map[string]string{
+					"provisioner":     env.Provisioner,
 					"cluster_context": "DR2", // Help identify which cluster this is
 					"image":           helpers.DefaultIptablesImageWithRegistry,
 				},
@@ -703,17 +660,18 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			if helpers.GetFaultInjectorTypeFromEnv() == helpers.FaultInjectorIptables {
 				cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR2, cDR1)
 			} else {
-				cidrs = GetFenceCIDRs(ctx, cDR1, env.Provisioner, "temp-nfc-"+nsName)
+				cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR2, cDR1, env.Provisioner, "")
 			}
 			if len(cidrs) == 0 {
 				Skip("L1-PROM-004 could not get CIDRs: for iptables set FENCE_CIDRS or FENCE_PEER_SERVICES/FENCE_TARGET_SERVICES; for NetworkFence set FENCE_CIDRS, wait for CSI client CIDRs, or ensure DR1 has node InternalIPs for fallback")
 			}
 
-			fenceBaselines := establishIptablesFenceBaselines(ctx, faultProvider, cidrs)
+			fenceBaselines := IptablesBaselinesOrGinkgoSkip(ctx, helpers.GetFaultInjectorTypeFromEnv(), faultProvider, cidrs)
 
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
 			By("[DR2] Fencing peer cluster to block access")
 			for _, cidr := range cidrs {
-				err = faultProvider.FenceIP(ctx, cidr, nil)
+				err = faultProvider.FenceIP(ctx, cidr, fenceParams)
 				Expect(err).NotTo(HaveOccurred(), "Failed to fence CIDR %s", cidr)
 			}
 
@@ -748,7 +706,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 
 			By("[DR2] Unfencing peer cluster to restore connectivity")
 			for _, cidr := range cidrs {
-				err = faultProvider.UnfenceIP(ctx, cidr, nil)
+				err = faultProvider.UnfenceIP(ctx, cidr, fenceParams)
 				Expect(err).NotTo(HaveOccurred(), "Failed to unfence CIDR %s", cidr)
 			}
 
@@ -757,7 +715,7 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			Eventually(func() bool {
 				lastUnfenceVerifyReason004 = ""
 				for _, cidr := range cidrs {
-					connected, err := faultProvider.VerifyConnectivity(ctx, cidr, false, fenceBaselineRef(fenceBaselines, cidr))
+					connected, err := faultProvider.VerifyConnectivity(ctx, cidr, false, helpers.BaselineForCIDR(fenceBaselines, cidr))
 					if err != nil {
 						lastUnfenceVerifyReason004 = fmt.Sprintf("VerifyConnectivity failed for %s: %v", cidr, err)
 						return false
@@ -804,8 +762,6 @@ var _ = Describe("PromoteVolumeReplication", func() {
 			By("Assertions: L1-PROM-004 — VR remains stable after unfence")
 			Expect(vrDR2.Status.State).To(Or(Equal(replicationv1alpha1.PrimaryState), Equal(replicationv1alpha1.UnknownState)),
 				"L1-PROM-004: VR state should remain Primary or Unknown after unfence, got %q", vrDR2.Status.State)
-
-			DeleteNetworkFenceWithCleanup(ctx, cDR2, nf)
 		})
 	})
 

--- a/test/e2e/replication/resync_volumereplication_test.go
+++ b/test/e2e/replication/resync_volumereplication_test.go
@@ -27,12 +27,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/test/e2e/helpers"
 )
 
-// hasVolumeReplicationCompletedCondition checks if VR has Completed=True condition.
-// This is used for resync operations where the state remains Secondary but Completed=True signals completion.
+// hasVolumeReplicationCompletedCondition is true when ConditionCompleted has Status=True.
+//
+// This is not sufficient to mean “resync is done”: after a successful ResyncVolume RPC the controller
+// runs setResyncCondition (internal/controller/replication.storage/status.go), which sets
+// ConditionCompleted=True (Reason Demoted) at the same time as ConditionResyncing=True until the CSI
+// driver reports Ready (ResyncVolumeResponse.ready). So Completed=True with Resyncing=True is normal
+// while the mirror catches up. Failed resync uses setFailedResyncCondition (Completed=False, Resyncing=False).
 func hasVolumeReplicationCompletedCondition(vr *replicationv1alpha1.VolumeReplication) bool {
 	for _, cond := range vr.Status.Conditions {
 		if cond.Type == replicationv1alpha1.ConditionCompleted && cond.Status == metav1.ConditionTrue {
@@ -42,9 +47,10 @@ func hasVolumeReplicationCompletedCondition(vr *replicationv1alpha1.VolumeReplic
 	return false
 }
 
-// hasResyncOperationCompleted checks if the resync operation has completed (Resyncing=False).
-// This is the key indicator that the resync RPC call finished, regardless of Degraded state.
-// After resync completes, Degraded may still be True as the mirror recovers.
+// hasResyncOperationCompleted is true when ConditionResyncing has Status=False (Reason NotResyncing).
+// The controller clears Resyncing after the driver reports resync ready (and applies setNotDegradedCondition),
+// or on failure via setFailedResyncCondition—pair with hasVolumeReplicationCompletedCondition to tell success
+// (Completed=True) from failure (Completed=False).
 func hasResyncOperationCompleted(vr *replicationv1alpha1.VolumeReplication) bool {
 	for _, cond := range vr.Status.Conditions {
 		if cond.Type == replicationv1alpha1.ConditionResyncing && cond.Status == metav1.ConditionFalse {
@@ -52,6 +58,13 @@ func hasResyncOperationCompleted(vr *replicationv1alpha1.VolumeReplication) bool
 		}
 	}
 	return false
+}
+
+// volumeReplicationResyncWaitSatisfied is the condition these specs use in Eventually: successful resync
+// reconciliation requires Completed=True and Resyncing=False. Do not drop either: Resyncing=False alone would
+// match failed resync (Completed=False).
+func volumeReplicationResyncWaitSatisfied(vr *replicationv1alpha1.VolumeReplication) bool {
+	return hasVolumeReplicationCompletedCondition(vr) && hasResyncOperationCompleted(vr)
 }
 
 var _ = Describe("ResyncVolumeReplication", func() {
@@ -123,13 +136,18 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			Expect(vrDR2.Status.State).To(Equal(replicationv1alpha1.SecondaryState), "Secondary should be in Secondary state")
 			Expect(hasReplicationSuccessCondition(vrDR2)).To(BeTrue(), "Secondary should have success condition")
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
+			var faultProvider helpers.PeerFenceProvider
+			var cidrs []string
+			var fenceBaselines map[string]*helpers.ConnectivityBaseline
 
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR2, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR2, nfc)
+				if faultProvider != nil {
+					if err := helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider); err != nil {
+						_, _ = fmt.Fprintf(GinkgoWriter, "[WARNING] L1-RSYNC-001 fault injection log collection: %v\n", err)
+					}
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -141,27 +159,104 @@ var _ = Describe("ResyncVolumeReplication", func() {
 				DeleteNamespace(cleanupCtx, cDR2, ns2)
 			})
 
-			By("L1-RSYNC-001: Creating NetworkFence to simulate split-brain (isolate secondary)")
-			if !IsNetworkFenceSupportAvailable() {
-				By("L1-RSYNC-001: NetworkFence not supported, simulating split-brain via demotion")
-				_ = cDR1.Get(ctx, client.ObjectKeyFromObject(vrDR1), vrDR1)
-				_, _ = fmt.Fprintf(GinkgoWriter, "  [NOTE] NetworkFence not available; skipping network isolation. Resync will proceed on healthy secondary.\n")
-			} else {
-				By("L1-RSYNC-001: NetworkFence supported, creating fence to simulate split-brain")
-				nfc, nf = CreateNetworkFenceAndWait(ctx, cDR2, nsName, env.Provisioner, secretName, secretNs)
-				By("L1-RSYNC-001: NetworkFence created, secondary is now isolated")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			fenceParams := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			fenceApplied := false
 
-				By("L1-RSYNC-001: Validating secondary replication state via GetVolumeReplicationInfo (post-fence, degraded)")
+			By("L1-RSYNC-001: Checking fault injection prerequisites (align with L1-PROM-003)")
+			if injector != helpers.FaultInjectorNone && !IsNetworkFenceSupportAvailable() && !helpers.HasPrivilegedDaemonSetSupport(ctx, cDR2) {
+				Skip("L1-RSYNC-001 requires either NetworkFence support or privileged DaemonSet capabilities for fault injection")
+			}
+
+			if injector != helpers.FaultInjectorNone {
+				By("L1-RSYNC-001: Resolving peer fence CIDRs for E2E_FAULT_INJECTOR")
+				if injector == helpers.FaultInjectorIptables {
+					cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR2, cDR1)
+				} else {
+					cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR2, cDR1, env.Provisioner, "")
+				}
+				if len(cidrs) == 0 {
+					Skip("L1-RSYNC-001 could not get CIDRs: for iptables set FENCE_CIDRS or FENCE_PEER_SERVICES/FENCE_TARGET_SERVICES; for NetworkFence set FENCE_CIDRS, wait for CSI client CIDRs, or ensure DR1 has node InternalIPs for fallback")
+				}
+				_, _ = fmt.Fprintf(GinkgoWriter, "  [L1-RSYNC-001] fencing peer CIDRs (injector=%s): %v\n", injector, cidrs)
+
+				var err error
+				faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+					Type:       injector,
+					Client:     cDR2,
+					RESTConfig: GetRESTConfigDR2(),
+					Namespace:  nsName,
+					ProviderParams: map[string]string{
+						"provisioner":     env.Provisioner,
+						"image":           helpers.DefaultIptablesImageWithRegistry,
+						"cluster_context": "DR2",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider for L1-RSYNC-001")
+
+				fenceBaselines = IptablesBaselinesOrGinkgoSkip(ctx, injector, faultProvider, cidrs)
+
+				By(fmt.Sprintf("L1-RSYNC-001: Fencing peer from DR2 via %s: %v", injector, cidrs))
+				for _, cidr := range cidrs {
+					Expect(faultProvider.FenceIP(ctx, cidr, fenceParams)).To(Succeed(), "FenceIP %s", cidr)
+				}
+				if injector == helpers.FaultInjectorIptables {
+					time.Sleep(5 * time.Second)
+					var lastFenceVerify string
+					Eventually(func() bool {
+						lastFenceVerify = ""
+						for _, cidr := range cidrs {
+							fenced, vErr := faultProvider.VerifyConnectivity(ctx, cidr, true, helpers.BaselineForCIDR(fenceBaselines, cidr))
+							if vErr != nil {
+								lastFenceVerify = fmt.Sprintf("VerifyConnectivity %s: %v", cidr, vErr)
+								return false
+							}
+							if !fenced {
+								lastFenceVerify = fmt.Sprintf("CIDR %s probes still match pre-fence reachability (expected partition)", cidr)
+								return false
+							}
+						}
+						return true
+					}, 2*time.Minute, 10*time.Second).Should(BeTrue(),
+						"L1-RSYNC-001: after iptables fence, DR2 must show partition vs baseline (CIDRs %v). %s", cidrs, lastFenceVerify)
+				}
+
+				fenceApplied = true
+				By("L1-RSYNC-001: Validating secondary replication state (post-fence, degraded)")
 				Eventually(func() bool {
 					_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 					_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] post-fence: %s\n", FormatVRStatus(vrDR2))
 					return HasVolumeReplicationErrorCondition(vrDR2)
 				}, 30*time.Second, 2*time.Second).Should(BeTrue(),
-					"Secondary should show error condition after network fence")
+					"Secondary should show error condition after fence")
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "  [NOTE] L1-RSYNC-001: E2E_FAULT_INJECTOR=none; resync without network isolation.\n")
 			}
 
-			By("L1-RSYNC-001: Removing NetworkFence to resolve split-brain")
-			DeleteNetworkFenceWithCleanup(ctx, cDR2, nf)
+			By("L1-RSYNC-001: Restoring connectivity (unfence) before resync")
+			if faultProvider != nil && fenceApplied {
+				for _, cidr := range cidrs {
+					Expect(faultProvider.UnfenceIP(ctx, cidr, fenceParams)).To(Succeed(), "UnfenceIP %s", cidr)
+				}
+				var lastUnfence string
+				Eventually(func() bool {
+					lastUnfence = ""
+					for _, cidr := range cidrs {
+						ok, vErr := faultProvider.VerifyConnectivity(ctx, cidr, false, helpers.BaselineForCIDR(fenceBaselines, cidr))
+						if vErr != nil {
+							lastUnfence = fmt.Sprintf("VerifyConnectivity %s: %v", cidr, vErr)
+							return false
+						}
+						if !ok {
+							lastUnfence = fmt.Sprintf("CIDR %s not yet matching reachable baseline after unfence", cidr)
+							return false
+						}
+					}
+					return true
+				}, 2*time.Minute, 10*time.Second).Should(BeTrue(),
+					"L1-RSYNC-001: after unfence, DR2 connectivity must match pre-fence reachability (CIDRs %v). %s", cidrs, lastUnfence)
+				helpers.SweepIptablesResidualAfterUnfence(ctx, injector, faultProvider)
+			}
 			By("L1-RSYNC-001: Triggering resync by updating VR to Resync state")
 			err := cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 			Expect(err).NotTo(HaveOccurred())
@@ -169,13 +264,13 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			err = cDR2.Update(ctx, vrDR2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update VR replicationState to Resync")
 
-			By("Waiting for VR to complete resync (checking Completed condition)")
+			By("Waiting for VR resync: Resyncing=False and Completed=True (Completed may stay True while Resyncing=True until driver reports ready)")
 			Eventually(func() bool {
 				_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
-				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] resync in progress: %s\n", FormatVRStatus(vrDR2))
-				return hasVolumeReplicationCompletedCondition(vrDR2) && hasResyncOperationCompleted(vrDR2)
+				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] resync poll: %s\n", FormatVRStatus(vrDR2))
+				return volumeReplicationResyncWaitSatisfied(vrDR2)
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
-				"VR Completed condition should be True and Resyncing=False after resync")
+				"expect Resyncing=False and Completed=True after resync (Resyncing=True with Completed=True means still catching up)")
 
 			By("L1-RSYNC-001: Assertion — data consistency confirmed")
 			_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
@@ -251,11 +346,11 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			err = cDR2.Update(ctx, vrDR2)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for first resync to complete (checking Completed condition)")
+			By("Waiting for first resync: Resyncing=False and Completed=True")
 			Eventually(func() bool {
 				_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] first resync: %s\n", FormatVRStatus(vrDR2))
-				return hasVolumeReplicationCompletedCondition(vrDR2) && hasResyncOperationCompleted(vrDR2)
+				return volumeReplicationResyncWaitSatisfied(vrDR2)
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
 			By("L1-RSYNC-002: Assertion — data consistency after first resync")
@@ -270,11 +365,11 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			err = cDR2.Update(ctx, vrDR2)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for second resync to complete (checking Completed condition)")
+			By("Waiting for second resync: Resyncing=False and Completed=True")
 			Eventually(func() bool {
 				_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] second resync: %s\n", FormatVRStatus(vrDR2))
-				return hasVolumeReplicationCompletedCondition(vrDR2) && hasResyncOperationCompleted(vrDR2)
+				return volumeReplicationResyncWaitSatisfied(vrDR2)
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
 			By("L1-RSYNC-002: Assertion — data consistency after second resync")
@@ -286,10 +381,21 @@ var _ = Describe("ResyncVolumeReplication", func() {
 
 	Describe("L1-RSYNC-003: Resync with NetworkFence (split-brain recovery)", func() {
 		It("L1-RSYNC-003: resync with secondary network-fenced (split-brain), expect resync completes after fence removal", func() {
-			By("L1-RSYNC-003: Create primary and secondary, apply NetworkFence, resolve, then resync")
+			By("L1-RSYNC-003: Create primary and secondary, apply fault injection fence on DR2, resolve, then resync")
 			SkipIfNotFullDR("L1-RSYNC-003", "requires two clusters (DR1_CONTEXT and DR2_CONTEXT)")
-			if !IsNetworkFenceSupportAvailable() {
-				Skip("L1-RSYNC-003: NetworkFence not supported on this setup")
+			injector := helpers.GetFaultInjectorTypeFromEnv()
+			if injector == helpers.FaultInjectorNone {
+				Skip("L1-RSYNC-003 requires fault injection (E2E_FAULT_INJECTOR=iptables|networkfence)")
+			}
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				if !IsNetworkFenceSupportAvailable() {
+					Skip("L1-RSYNC-003 (networkfence) requires NetworkFence support on this setup")
+				}
+			case helpers.FaultInjectorIptables:
+				if !helpers.HasPrivilegedDaemonSetSupport(ctx, GetK8sClientForCluster(ClusterDR2)) {
+					Skip("L1-RSYNC-003 (iptables) requires privileged DaemonSet support on DR2")
+				}
 			}
 
 			cDR1 := GetK8sClientForCluster(ClusterDR1)
@@ -328,13 +434,15 @@ var _ = Describe("ResyncVolumeReplication", func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] %s\n", FormatVRStatus(v))
 			})
 
-			var nfc *csiaddonsv1alpha1.NetworkFenceClass
-			var nf *csiaddonsv1alpha1.NetworkFence
+			var faultProvider helpers.PeerFenceProvider
+			var cidrs []string
 
 			DeferCleanup(func() {
 				cleanupCtx := context.Background()
-				DeleteNetworkFenceWithCleanup(cleanupCtx, cDR2, nf)
-				DeleteNetworkFenceClassWithCleanup(cleanupCtx, cDR2, nfc)
+				if faultProvider != nil {
+					_ = helpers.CollectFaultInjectionLogs(cleanupCtx, faultProvider)
+					_ = faultProvider.Cleanup(cleanupCtx)
+				}
 				DeleteVolumeReplicationWithCleanup(cleanupCtx, cDR2, vrDR2)
 				DeleteVolumeReplicationClassWithCleanup(cleanupCtx, cDR2, vrcDR2)
 				DeletePVCWithCleanup(cleanupCtx, cDR2, pvcDR2)
@@ -346,8 +454,39 @@ var _ = Describe("ResyncVolumeReplication", func() {
 				DeleteNamespace(cleanupCtx, cDR2, ns2)
 			})
 
-			By("L1-RSYNC-003: Creating NetworkFence to isolate secondary")
-			nfc, nf = CreateNetworkFenceAndWait(ctx, cDR2, nsName, env.Provisioner, secretName, secretNs)
+			var err error
+			faultProvider, err = helpers.NewFaultInjectionProvider(helpers.FaultInjectionConfig{
+				Type:       injector,
+				Client:     cDR2,
+				RESTConfig: GetRESTConfigDR2(),
+				Namespace:  nsName,
+				ProviderParams: map[string]string{
+					"provisioner":     env.Provisioner,
+					"image":           helpers.DefaultIptablesImageWithRegistry,
+					"cluster_context": "DR2",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred(), "NewFaultInjectionProvider")
+			if !faultProvider.IsSupported(ctx) {
+				Skip(fmt.Sprintf("L1-RSYNC-003 (%s): fault injection not supported on this cluster", injector))
+			}
+			switch injector {
+			case helpers.FaultInjectorNetworkFence:
+				cidrs = GetFenceCIDRsWithPeerNodeClient(ctx, cDR2, cDR1, env.Provisioner, "")
+			case helpers.FaultInjectorIptables:
+				cidrs = GetFenceCIDRsForFaultInjectionPeer(ctx, cDR2, cDR1)
+			}
+			if len(cidrs) == 0 {
+				Skip("L1-RSYNC-003 could not get fence CIDRs (set FENCE_CIDRS or discovery env vars)")
+			}
+			fp := map[string]string{"secretName": secretName, "secretNamespace": secretNs}
+			By(fmt.Sprintf("L1-RSYNC-003: Fencing peer from DR2 via %s: %v", injector, cidrs))
+			for _, cidr := range cidrs {
+				Expect(faultProvider.FenceIP(ctx, cidr, fp)).To(Succeed(), "FenceIP %s", cidr)
+			}
+			if injector == helpers.FaultInjectorIptables {
+				time.Sleep(5 * time.Second)
+			}
 
 			By("L1-RSYNC-003: Validating secondary is fenced (split-brain state)")
 			Eventually(func() bool {
@@ -357,21 +496,24 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
 				"Secondary should show error after fence applied")
 
-			By("L1-RSYNC-003: Removing NetworkFence to resolve split-brain")
-			DeleteNetworkFenceWithCleanup(ctx, cDR2, nf)
+			By("L1-RSYNC-003: Unfencing peer before resync")
+			for _, cidr := range cidrs {
+				Expect(faultProvider.UnfenceIP(ctx, cidr, fp)).To(Succeed(), "UnfenceIP %s", cidr)
+			}
+			helpers.SweepIptablesResidualAfterUnfence(ctx, injector, faultProvider)
 
 			By("L1-RSYNC-003: Triggering resync after split-brain recovery")
-			err := cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
+			err = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 			Expect(err).NotTo(HaveOccurred())
 			vrDR2.Spec.ReplicationState = replicationv1alpha1.Resync
 			err = cDR2.Update(ctx, vrDR2)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for resync to complete (checking Completed condition)")
+			By("Waiting for resync: Resyncing=False and Completed=True")
 			Eventually(func() bool {
 				_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] resync: %s\n", FormatVRStatus(vrDR2))
-				return hasVolumeReplicationCompletedCondition(vrDR2) && hasResyncOperationCompleted(vrDR2)
+				return volumeReplicationResyncWaitSatisfied(vrDR2)
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
 			By("L1-RSYNC-003: Assertion — data consistency after resync")
@@ -442,11 +584,11 @@ var _ = Describe("ResyncVolumeReplication", func() {
 			err = cDR2.Update(ctx, vrDR2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update VR to Resync state")
 
-			By("Waiting for resync to complete (checking Completed condition)")
+			By("Waiting for resync: Resyncing=False and Completed=True")
 			Eventually(func() bool {
 				_ = cDR2.Get(ctx, client.ObjectKeyFromObject(vrDR2), vrDR2)
 				_, _ = fmt.Fprintf(GinkgoWriter, "  [DR2][VR] force-resync: %s\n", FormatVRStatus(vrDR2))
-				return hasVolumeReplicationCompletedCondition(vrDR2) && hasResyncOperationCompleted(vrDR2)
+				return volumeReplicationResyncWaitSatisfied(vrDR2)
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
 			By("L1-RSYNC-004: Assertion — data consistency after force resync")

--- a/test/e2e/replication/suite_test.go
+++ b/test/e2e/replication/suite_test.go
@@ -192,21 +192,23 @@ var _ = BeforeSuite(func() {
 
 	Logf("[SETUP]", "ready")
 
-	// Deploy iptables manager DaemonSet for network fence tests
-	Logf("[SETUP]", "deploying iptables manager DaemonSet for network fence capability")
-	if fullDR {
-		// Deploy to both DR1 and DR2 clusters with ConfigMaps
-		if err := helpers.DeployIptablesServiceWithConfigMap(context.Background(), k8sClientDR1, "csi-addons-system"); err != nil {
-			Logf("[SETUP]", "WARNING: iptables service deployment to DR1 failed: %v (continuing with tests)", err)
-		}
-		if err := helpers.DeployIptablesServiceWithConfigMap(context.Background(), k8sClientDR2, "csi-addons-system"); err != nil {
-			Logf("[SETUP]", "WARNING: iptables service deployment to DR2 failed: %v (continuing with tests)", err)
+	// iptables DaemonSet is only for E2E_FAULT_INJECTOR=iptables (or unset → iptables). Skip for networkfence / none.
+	if helpers.GetFaultInjectorTypeFromEnv() == helpers.FaultInjectorIptables {
+		Logf("[SETUP]", "deploying iptables manager DaemonSet for iptables fault injection (suite start refresh; set %s=true to skip delete/recreate)", helpers.EnvE2EIptablesSkipSuiteDSRecreate)
+		if fullDR {
+			if err := helpers.EnsureFreshSuiteIptablesDaemonSet(context.Background(), k8sClientDR1, "csi-addons-system"); err != nil {
+				Logf("[SETUP]", "WARNING: iptables service deployment to DR1 failed: %v (continuing with tests)", err)
+			}
+			if err := helpers.EnsureFreshSuiteIptablesDaemonSet(context.Background(), k8sClientDR2, "csi-addons-system"); err != nil {
+				Logf("[SETUP]", "WARNING: iptables service deployment to DR2 failed: %v (continuing with tests)", err)
+			}
+		} else {
+			if err := helpers.EnsureFreshSuiteIptablesDaemonSet(context.Background(), k8sClient, "csi-addons-system"); err != nil {
+				Logf("[SETUP]", "WARNING: iptables service deployment failed: %v (continuing with tests)", err)
+			}
 		}
 	} else {
-		// Deploy to primary cluster with ConfigMap
-		if err := helpers.DeployIptablesServiceWithConfigMap(context.Background(), k8sClient, "csi-addons-system"); err != nil {
-			Logf("[SETUP]", "WARNING: iptables service deployment failed: %v (continuing with tests)", err)
-		}
+		Logf("[SETUP]", "skipping iptables manager DaemonSet (E2E_FAULT_INJECTOR=%s)", helpers.GetFaultInjectorTypeFromEnv())
 	}
 
 	// Detect NetworkFence support once at suite level for efficiency

--- a/test/e2e/utils/README.md
+++ b/test/e2e/utils/README.md
@@ -1,18 +1,22 @@
-# CSI-Addons E2E Testing Utilities
+# CSI-Addons end-to-end testing utilities
 
-This directory contains utilities and tools specifically for E2E testing, particularly for network fault injection using iptables.
+This directory contains utilities and tools specifically for end-to-end testing, particularly for network fault injection using iptables.
 
 ## Files
 
 ### Iptables Image Management
+
 - **`Containerfile.iptables`** - Dockerfile for building the iptables manager image with networking tools
 - **`Makefile.iptables`** - Specialized Makefile for building/managing the iptables image
 - **`prepare-iptables-image.sh`** - Script to build, tag, and verify the iptables image locally
 - **`preload-iptables-image.sh`** - **CONSOLIDATED SCRIPT** - Loads iptables images to DR clusters for testing
+- **`validate-iptables-fence.sh`** - End-to-end validation of fence/unfence (invoked via `Makefile.iptables` `validate-network-fence`)
+- **`emergency-cleanup-iptables.sh`** - Host-side cleanup of leftover iptables fence rules (invoked via `Makefile.iptables` `emergency-cleanup`)
 
 ## Usage
 
 ### Building Iptables Image
+
 ```bash
 # From repo root:
 make -f test/e2e/utils/Makefile.iptables build-iptables-image
@@ -23,6 +27,7 @@ make build-iptables-image
 ```
 
 ### Preparing and Loading Images to Clusters
+
 ```bash
 # 1. Prepare image locally:
 ./test/e2e/utils/prepare-iptables-image.sh
@@ -34,18 +39,40 @@ DR1_CONTEXT=dr1 DR2_CONTEXT=dr2 ./test/e2e/utils/preload-iptables-image.sh
 VERIFY_ONLY=true ./test/e2e/utils/preload-iptables-image.sh
 ```
 
+### Validate fencing and full prep flow
+
+```bash
+make -f test/e2e/utils/Makefile.iptables validate-network-fence
+make -f test/e2e/utils/Makefile.iptables test-e2e-flow   # build + load + validate
+```
+
+### Emergency cleanup (leftover REJECT rules / DaemonSet namespaces)
+
+```bash
+make -f test/e2e/utils/Makefile.iptables emergency-cleanup
+# Or directly, e.g. single context and namespace pattern:
+./test/e2e/utils/emergency-cleanup-iptables.sh dr1 'e2e-*'
+```
+
+## Troubleshooting
+
+- **Replication test namespaces / VR / NetworkFence leftovers:** run `./hack/clean-replication-e2e-resources.sh` (or `make clean-replication-e2e`) from the repo root. See `docs/networkfence-troubleshooting.md` for stuck `NetworkFence` resources.
+- **Image build path:** the iptables image is defined only under `test/e2e/utils/Containerfile.iptables`. `hack/run-replication-e2e.sh` builds from that path when the default image tag is used and the image is missing locally.
+
 ## Consolidation Notes
 
 This directory was created to organize iptables-related testing utilities that were previously scattered:
 
 **Moved from hack/ to test/e2e/utils/:**
+
 - `hack/preload-iptables-simple.sh` + `hack/preload-iptables-image.sh` → `preload-iptables-image.sh` (consolidated)
-- `hack/prepare-iptables-image.sh` → `prepare-iptables-image.sh`  
+- `hack/prepare-iptables-image.sh` → `prepare-iptables-image.sh`
 - `build/Containerfile.iptables` → `Containerfile.iptables`
 - Main `Makefile` iptables target → `Makefile.iptables`
 
 **Rationale:**
-- Iptables functionality is only used for E2E network fault injection testing, not the main CSI-Addons controller
+
+- Iptables functionality is only used for end-to-end network fault injection testing, not the main CSI-Addons controller
 - Consolidating duplicate preload scripts reduces maintenance burden
 - Organizing test-specific files in test directories improves project structure
 


### PR DESCRIPTION
Refactor replication tests to use fault injection framework

## Changes
- Refactor replication e2e tests to use new fault injection framework
- Add conflict retry logic to finalizer removal functions
- Resolve yamllint issues in YAML templates and configs
- Update documentation for E2E test paths and Makefile targets
- Remove unused scripts and fix iptables image build paths
- Improve replication logs and gate iptables setup on injector
- Align tests with L1-RSYNC-001 baseline and verify procedures

## Key Files Modified
- test/e2e/replication/enable_volumereplication_test.go
- test/e2e/replication/promote_volumereplication_test.go
- test/e2e/replication/resync_volumereplication_test.go
- Various e2e test utilities

## Commits (6 total)
Applies fault injection framework to all replication tests

## Part of PR #17 Refactoring
Depends on: PR-fault-injection (#28) ✓ merged
Unblocks: PR-hooks